### PR TITLE
Add dynamic sky and sun lighting system

### DIFF
--- a/src/world/sky.js
+++ b/src/world/sky.js
@@ -1,90 +1,38 @@
-import {
-  BackSide,
-  Color,
-  Mesh,
-  ShaderMaterial,
-  SphereGeometry
-} from 'three';
+import { Sky } from 'three/examples/jsm/objects/Sky.js';
 
-// Predefine key colors for the different phases of a day cycle.
-// These colors are mixed together in the shader so the sky smoothly
-// transitions between dawn, day, dusk, and night.
-const DAWN_COLOR = new Color('#f9d29d');
-const DAY_COLOR = new Color('#87ceeb');
-const DUSK_COLOR = new Color('#f28482');
-const NIGHT_COLOR = new Color('#0b1d51');
-
-// Helper to convert Three.js Color objects into the format GLSL expects.
-const toVec3 = (color) => color.toArray();
-
+// The Sky helper from Three.js ships with a rich atmospheric scattering
+// shader. We only need to instantiate it once, configure the uniforms,
+// and add it to the scene.
 export const createSky = (scene) => {
-  // Build a sphere that will completely surround the rest of the scene.
-  // Because we only want to see the inside of the sphere (like standing
-  // inside of a planetarium dome) we render the back side of the faces.
-  const geometry = new SphereGeometry(500, 32, 32);
+  const sky = new Sky();
 
-  const skyMaterial = new ShaderMaterial({
-    side: BackSide,
-    uniforms: {
-      timeOfDay: { value: 0 }
-    },
-    vertexShader: `
-      void main() {
-        // For a sky dome we simply push the vertices through the normal
-        // model-view-projection pipeline without any deformation.
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-      }
-    `,
-    fragmentShader: `
-      uniform float timeOfDay; // Ranges from 0.0 to 1.0 over the course of a day
+  // The sky needs to be scaled up dramatically so that it surrounds the
+  // entire world. The helper conveniently exposes a setScalar method for
+  // uniform scaling.
+  sky.scale.setScalar(450000);
+  scene.add(sky);
 
-      // Predefined colors for the sky phases
-      const vec3 dawnColor = vec3(${toVec3(DAWN_COLOR).join(', ')});
-      const vec3 dayColor = vec3(${toVec3(DAY_COLOR).join(', ')});
-      const vec3 duskColor = vec3(${toVec3(DUSK_COLOR).join(', ')});
-      const vec3 nightColor = vec3(${toVec3(NIGHT_COLOR).join(', ')});
+  // These values control how light scatters through the atmosphere.
+  // Feel free to tweak them to taste if you want a hazier or crisper look.
+  const uniforms = sky.material.uniforms;
+  uniforms.turbidity.value = 10;
+  uniforms.rayleigh.value = 2;
+  uniforms.mieCoefficient.value = 0.005;
+  uniforms.mieDirectionalG.value = 0.8;
 
-      // Helper: perform a smooth interpolation between colors around
-      // evenly spaced time checkpoints.
-      vec3 getSkyColor(float t) {
-        // Define quarter points for dawn (0.0), day (0.25), dusk (0.5),
-        // and night (0.75). The cycle wraps back to dawn at 1.0.
-        if (t < 0.25) {
-          float localT = smoothstep(0.0, 0.25, t);
-          return mix(dawnColor, dayColor, localT);
-        } else if (t < 0.5) {
-          float localT = smoothstep(0.25, 0.5, t);
-          return mix(dayColor, duskColor, localT);
-        } else if (t < 0.75) {
-          float localT = smoothstep(0.5, 0.75, t);
-          return mix(duskColor, nightColor, localT);
-        }
+  // The sun position uniform is what ultimately determines the color of the
+  // sky gradient. We initialise it to a sensible default pointing straight up.
+  uniforms.sunPosition.value.set(0, 1, 0);
 
-        float localT = smoothstep(0.75, 1.0, t);
-        return mix(nightColor, dawnColor, localT);
-      }
-
-      void main() {
-        // We could use the world position to add vertical gradients later,
-        // but for now we simply return the color for the current time.
-        gl_FragColor = vec4(getSkyColor(timeOfDay), 1.0);
-      }
-    `
-  });
-
-  const skyDome = new Mesh(geometry, skyMaterial);
-  scene.add(skyDome);
-
-  return {
-    dome: skyDome,
-    material: skyMaterial
-  };
+  return sky;
 };
 
-export const updateSky = (skyObject, timeOfDay) => {
-  if (!skyObject?.material) return;
+// Update the sun position used by the atmospheric shader. The helper expects
+// a world-space position, so we simply copy over the provided direction.
+export const updateSky = (sky, sunDirection) => {
+  if (!sky?.material?.uniforms?.sunPosition) return;
 
-  // Wrap the time value so callers can freely increase it past 1.0.
-  const normalizedTime = ((timeOfDay % 1) + 1) % 1;
-  skyObject.material.uniforms.timeOfDay.value = normalizedTime;
+  // Normalise a copy to avoid mutating the original vector passed in.
+  const sunPosition = sky.material.uniforms.sunPosition.value;
+  sunPosition.copy(sunDirection).normalize();
 };


### PR DESCRIPTION
## Summary
- replace the hand-authored shader dome with Three.js's Sky helper and configure atmospheric uniforms
- add a directional/hemisphere lighting rig that reacts to the animated sun direction
- drive the sun vector from main.js so both the sky and lighting update every frame

## Testing
- npm install *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68e069879c68832788bc9f0befedb704