### PR TITLE
Add night sky elements with stars and moon lighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,8 @@
 // main.js
 
 import * as THREE from "three";
-import { Sky } from "three/examples/jsm/objects/Sky.js";
-import { createSky, updateSky } from "./world/sky.js";
-import { createLighting, updateLighting } from "./world/lighting.js";
+import { createSky, updateSky, createStars, updateStars } from "./world/sky.js";
+import { createLighting, updateLighting, createMoon, updateMoon } from "./world/lighting.js";
 
 function init() {
   // Renderer
@@ -21,9 +20,11 @@ function init() {
   );
   camera.position.set(0, 5, 10);
 
-  // Sky & lighting
+  // Sky, stars & lighting
   const skyObj = createSky(scene);
   const lights = createLighting(scene);
+  const stars = createStars(scene);
+  const moon = createMoon(scene);
 
   // Optional: add a ground plane
   {
@@ -53,9 +54,11 @@ function init() {
       0
     );
 
-    // Update sky and lighting
+    // Update sky dome, stars, sun light and moon.
     updateSky(skyObj, sun);
     updateLighting(lights, sun);
+    updateStars(stars, sun.y);
+    updateMoon(moon, sun);
 
     // Render
     renderer.render(scene, camera);

--- a/src/world/lighting.js
+++ b/src/world/lighting.js
@@ -22,20 +22,73 @@ export function updateLighting(lights, sun) {
   // You can modulate intensity & color based on sun elevation
   const elevation = sun.y;  // approximate measure, -1 to +1
 
-  // Example: simple fade in/out
-  const intensity = THREE.MathUtils.clamp(elevation, 0, 1);
-  sunLight.intensity = intensity * 1.5;
+  // Blend the sun light intensity smoothly based on the sun elevation.
+  const dayFactor = THREE.MathUtils.smoothstep(elevation, -0.1, 0.3);
+  sunLight.intensity = THREE.MathUtils.lerp(0.05, 1.5, dayFactor);
 
   // Color shift: warm dawn/dusk, cooler midday
   const middayColor = new THREE.Color(0xffffff);
   const dawnColor = new THREE.Color(0xffcc99);
   const nightColor = new THREE.Color(0x223355);
 
-  // map elevation to 0–1
-  const t = THREE.MathUtils.smoothstep(elevation, 0, 1);
-  sunLight.color.copy(dawnColor).lerp(middayColor, t);
+  sunLight.color.copy(nightColor)
+    .lerp(dawnColor, THREE.MathUtils.smoothstep(elevation, -0.05, 0.1))
+    .lerp(middayColor, dayFactor);
 
-  // Hemisphere light: sky vs ground
-  hemiLight.intensity = 0.5 + intensity * 0.5;
-  hemiLight.color = new THREE.Color(0x88bbff).lerp(new THREE.Color(0x111133), 1 - t);
+  // Hemisphere light: sky vs ground. Keep a little ambient at night.
+  hemiLight.intensity = THREE.MathUtils.lerp(0.15, 1.0, dayFactor);
+  hemiLight.color = new THREE.Color(0x111133).lerp(new THREE.Color(0x88bbff), dayFactor);
+}
+
+export function createMoon(scene) {
+  // A dim directional light paired with a small mesh to represent the moon.
+  const moonLight = new THREE.DirectionalLight(0xbfdfff, 0.2);
+  moonLight.castShadow = false;
+
+  // Small emissive sphere so we can see where the moon is in the sky.
+  const moonGeometry = new THREE.SphereGeometry(5, 16, 16);
+  const moonMaterial = new THREE.MeshBasicMaterial({ color: 0xeef7ff, transparent: true, opacity: 0.3 });
+  const moonMesh = new THREE.Mesh(moonGeometry, moonMaterial);
+
+  const moonGroup = new THREE.Group();
+  moonGroup.add(moonLight);
+  moonGroup.add(moonMesh);
+
+  scene.add(moonGroup);
+  scene.add(moonLight.target);
+
+  return { light: moonLight, mesh: moonMesh, group: moonGroup };
+}
+
+export function updateMoon(moon, sun) {
+  if (!moon) return;
+
+  const { light, mesh, group } = moon;
+  const moonDirection = sun.clone().multiplyScalar(-1).normalize();
+
+  // Position the moon opposite the sun on a large radius so it stays in the sky dome.
+  const radius = 400;
+  const position = moonDirection.clone().multiplyScalar(radius);
+  group.position.copy(position);
+
+  // Aim the light from the moon toward the origin (our world centre).
+  light.position.set(0, 0, 0);
+  light.target.position.set(0, 0, 0);
+  light.target.updateMatrixWorld();
+
+  if (mesh) {
+    // Keep the moon mesh centred on the group so it rides along with the light.
+    mesh.position.set(0, 0, 0);
+  }
+
+  // Brighter moon when the sun is well below the horizon.
+  const sunHeight = sun.y;
+  const nightFactor = THREE.MathUtils.clamp(-sunHeight, 0, 1);
+  const targetIntensity = THREE.MathUtils.lerp(0.05, 0.25, nightFactor);
+  light.intensity = THREE.MathUtils.lerp(light.intensity, targetIntensity, 0.1);
+  if (mesh && mesh.material) {
+    const targetOpacity = THREE.MathUtils.lerp(0.3, 1.0, nightFactor);
+    mesh.material.opacity = THREE.MathUtils.lerp(mesh.material.opacity, targetOpacity, 0.1);
+    mesh.material.transparent = true;
+  }
 }

--- a/src/world/sky.js
+++ b/src/world/sky.js
@@ -2,6 +2,10 @@
 import * as THREE from "three";
 import { Sky } from "three/examples/jsm/objects/Sky.js";
 
+// Constants used for the procedural star field.
+const STAR_COUNT = 1200;
+const STAR_FIELD_RADIUS = 1000;
+
 export function createSky(scene) {
   const sky = new Sky();
   sky.scale.setScalar(450000);  // make it very large
@@ -27,4 +31,68 @@ export function updateSky(skyObj, sun) {
   const { sky } = skyObj;
   // set the uniform for sun position
   sky.material.uniforms[ "sunPosition" ].value.copy(sun);
+}
+
+export function createStars(scene) {
+  // Create a simple star field using THREE.Points and randomised vertices.
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(STAR_COUNT * 3);
+  const colors = new Float32Array(STAR_COUNT * 3);
+
+  for (let i = 0; i < STAR_COUNT; i++) {
+    // Generate a random unit direction so stars wrap the whole sky dome.
+    const direction = new THREE.Vector3(
+      Math.random() * 2 - 1,
+      Math.random() * 2 - 1,
+      Math.random() * 2 - 1
+    ).normalize();
+
+    const distance = STAR_FIELD_RADIUS * (0.8 + Math.random() * 0.2);
+    const idx = i * 3;
+    positions[idx] = direction.x * distance;
+    positions[idx + 1] = direction.y * distance;
+    positions[idx + 2] = direction.z * distance;
+
+    // Give each star a slightly different brightness for variation.
+    const brightness = 0.5 + Math.random() * 0.5;
+    colors[idx] = brightness;
+    colors[idx + 1] = brightness;
+    colors[idx + 2] = brightness;
+  }
+
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+
+  const material = new THREE.PointsMaterial({
+    size: 1.2,
+    sizeAttenuation: true,
+    vertexColors: true,
+    transparent: true,
+    opacity: 0, // Start invisible; we fade the stars in at night.
+    depthWrite: false,
+  });
+
+  const stars = new THREE.Points(geometry, material);
+  stars.matrixAutoUpdate = false;
+  stars.updateMatrix();
+  scene.add(stars);
+
+  return stars;
+}
+
+export function updateStars(stars, sunHeight) {
+  if (!stars) return;
+
+  const material = stars.material;
+  if (!material) return;
+
+  // Use the sun height to determine how visible the stars should be.
+  const targetOpacity = THREE.MathUtils.clamp(
+    1 - THREE.MathUtils.smoothstep(sunHeight, -0.1, 0.2),
+    0,
+    1
+  );
+
+  // Lerp towards the target so the transition feels soft.
+  material.opacity = THREE.MathUtils.lerp(material.opacity, targetOpacity, 0.05);
 }


### PR DESCRIPTION
## Summary
- create a procedural star field that fades in as the sun sets
- add a moon light and mesh that mirrors the sun position for night scenes
- smooth lighting transitions between day and night and wire updates into the render loop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e06b4a7d5c8327b56ec0bbe9d6850e