### PR TITLE
Add beginner-friendly main character controller

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 import * as THREE from "three";
 import { createSky, updateSky, createStars, updateStars } from "./world/sky.js";
 import { createLighting, updateLighting, createMoon, updateMoon } from "./world/lighting.js";
+import { MainCharacter } from "./world/mainCharacter.js";
 
 function init() {
   const renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -36,13 +37,17 @@ function init() {
     scene.add(ground);
   }
 
+  // Create our controllable main character after the world is ready.
+  const character = new MainCharacter(scene, camera);
+
   const clock = new THREE.Clock();
   const dayDuration = 60; // seconds for full cycle
 
   function animate() {
     requestAnimationFrame(animate);
 
-    const elapsed = clock.getElapsedTime();
+    const deltaTime = clock.getDelta();
+    const elapsed = clock.elapsedTime;
     const phase = (elapsed % dayDuration) / dayDuration;
 
     const theta = phase * Math.PI * 2;
@@ -58,6 +63,9 @@ function init() {
     // Fade the stars in and out depending on the time of day.
     updateStars(stars, phase);
     updateMoon(moon, sunDir);
+
+    // Update player movement, rotation, and the following camera.
+    character.update(deltaTime);
 
     renderer.render(scene, camera);
   }

--- a/src/world/mainCharacter.js
+++ b/src/world/mainCharacter.js
@@ -1,7 +1,7 @@
 // src/world/mainCharacter.js
-// Simple playable character controller that demonstrates how to move a mesh
-// around a Three.js scene using keyboard input. Everything is commented for
-// beginners so feel free to explore and tweak!
+// Beginner-friendly player controller that demonstrates how to move a mesh
+// around a Three.js world using keyboard input. Every major step is commented
+// so you can follow along with what is happening under the hood.
 
 import {
   BoxGeometry,
@@ -11,8 +11,10 @@ import {
   MathUtils,
 } from "three";
 
-// Reusable vectors so we do not create new temporary objects every frame.
-const scratchDirection = new Vector3();
+// Re-use a couple of vectors each frame so we avoid creating lots of temporary
+// objects. This keeps garbage collection from interrupting our animation loop.
+const scratchInputDirection = new Vector3();
+const scratchWorldDirection = new Vector3();
 const scratchCameraOffset = new Vector3();
 const scratchLookTarget = new Vector3();
 const WORLD_UP = new Vector3(0, 1, 0);
@@ -22,41 +24,47 @@ export class MainCharacter {
     this.scene = scene;
     this.camera = camera;
 
-    // Provide friendly defaults while allowing callers to override them.
-    this.options = {
-      speed: options.speed ?? 5, // Movement speed (units per second)
-      angularSpeed: options.angularSpeed ?? Math.PI * 2, // Radians per second
-      cameraOffset:
-        options.cameraOffset?.clone?.() ?? new Vector3(0, 2, 6), // Camera follow offset
-    };
+    // Store the basic configuration with sensible defaults so new developers
+    // can create a character without passing any extra parameters.
+    this.speed = options.speed ?? 5; // Units moved per second.
+    this.angularSpeed = options.angularSpeed ?? 3; // Radians turned per second.
+    this.cameraOffset =
+      options.cameraOffset?.clone?.() ?? new Vector3(0, 2, 5); // Third-person follow distance.
 
-    // Create a very simple placeholder mesh so we can see the character.
+    // Create a very simple placeholder mesh so we can see something in the
+    // scene. You can later swap this out for a character model or animated rig.
     const geometry = new BoxGeometry(1, 2, 1);
     const material = new MeshStandardMaterial({ color: 0x6699ff });
     this.mesh = new Mesh(geometry, material);
     this.mesh.castShadow = true;
-    this.mesh.position.set(0, 1, 0); // Lift the box so it sits on the ground.
+
+    // Place the mesh so it sits on the ground and face it toward the negative Z
+    // axis (the direction our "forward" input will move toward).
+    this.mesh.position.set(0, 1, 0);
+    this.yaw = 0; // When yaw is 0 the character looks down the negative Z axis.
+    this.mesh.rotation.y = this.yaw;
 
     scene.add(this.mesh);
 
-    // Track the desired movement direction using simple boolean flags.
-    this.movement = {
-      forward: false,
-      backward: false,
-      left: false,
-      right: false,
-    };
+    // Flags that track which movement keys are currently pressed.
+    this.moveForward = false;
+    this.moveBackward = false;
+    this.moveLeft = false;
+    this.moveRight = false;
 
-    // Bind the event handlers so we can add and remove them if needed later.
+    // Bind event handlers once so we can add/remove them cleanly if the
+    // character is destroyed later.
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onKeyUp = this.onKeyUp.bind(this);
 
-    // Listen for key presses. These toggle the movement flags above.
+    // Listen for both WASD and arrow keys so people with different keyboard
+    // preferences can play immediately.
     window.addEventListener("keydown", this.onKeyDown);
     window.addEventListener("keyup", this.onKeyUp);
   }
 
-  // Remember to clean up the listeners if this character is ever destroyed.
+  // If you ever remove the character from the scene call dispose() so the
+  // keyboard listeners are cleaned up and do not leak memory.
   dispose() {
     window.removeEventListener("keydown", this.onKeyDown);
     window.removeEventListener("keyup", this.onKeyUp);
@@ -65,16 +73,20 @@ export class MainCharacter {
   onKeyDown(event) {
     switch (event.code) {
       case "KeyW":
-        this.movement.forward = true;
+      case "ArrowUp":
+        this.moveForward = true;
         break;
       case "KeyS":
-        this.movement.backward = true;
+      case "ArrowDown":
+        this.moveBackward = true;
         break;
       case "KeyA":
-        this.movement.left = true;
+      case "ArrowLeft":
+        this.moveLeft = true;
         break;
       case "KeyD":
-        this.movement.right = true;
+      case "ArrowRight":
+        this.moveRight = true;
         break;
       default:
         break;
@@ -84,72 +96,80 @@ export class MainCharacter {
   onKeyUp(event) {
     switch (event.code) {
       case "KeyW":
-        this.movement.forward = false;
+      case "ArrowUp":
+        this.moveForward = false;
         break;
       case "KeyS":
-        this.movement.backward = false;
+      case "ArrowDown":
+        this.moveBackward = false;
         break;
       case "KeyA":
-        this.movement.left = false;
+      case "ArrowLeft":
+        this.moveLeft = false;
         break;
       case "KeyD":
-        this.movement.right = false;
+      case "ArrowRight":
+        this.moveRight = false;
         break;
       default:
         break;
     }
   }
 
-  update(deltaTime, sunDir) {
+  update(deltaTime) {
     if (!this.mesh) return;
 
-    // deltaTime is the time since the last frame. Multiplying by speed makes
-    // the movement frame-rate independent.
-    const moveAmount = this.options.speed * deltaTime;
+    // --- Movement ---------------------------------------------------------
+    // Build a direction vector from the currently pressed keys. Negative Z is
+    // forward, positive Z is backward, and the X axis handles strafing.
+    const direction = scratchInputDirection.set(0, 0, 0);
+    if (this.moveForward) direction.z -= 1;
+    if (this.moveBackward) direction.z += 1;
+    if (this.moveLeft) direction.x -= 1;
+    if (this.moveRight) direction.x += 1;
 
-    // Figure out which direction we should be moving on the XZ plane.
-    const direction = scratchDirection.set(0, 0, 0);
-    if (this.movement.forward) direction.z -= 1;
-    if (this.movement.backward) direction.z += 1;
-    if (this.movement.left) direction.x -= 1;
-    if (this.movement.right) direction.x += 1;
-
-    // Normalize so diagonal movement is not faster than straight movement.
     if (direction.lengthSq() > 0) {
+      // Normalize so diagonal movement is not faster than straight movement.
       direction.normalize();
 
-      // Face the direction we are traveling by turning towards the target angle.
-      const targetAngle = Math.atan2(direction.x, direction.z);
-      const currentAngle = this.mesh.rotation.y;
+      // Determine the yaw (rotation around the Y axis) the player should face.
+      const targetYaw = Math.atan2(direction.x, -direction.z);
       const angleDiff = MathUtils.euclideanModulo(
-        targetAngle - currentAngle + Math.PI,
+        targetYaw - this.yaw + Math.PI,
         Math.PI * 2
       ) - Math.PI;
-      const maxTurn = this.options.angularSpeed * deltaTime;
+      const maxTurn = this.angularSpeed * deltaTime;
       const clampedTurn = MathUtils.clamp(angleDiff, -maxTurn, maxTurn);
-      this.mesh.rotation.y = currentAngle + clampedTurn;
+      this.yaw += clampedTurn;
+      this.mesh.rotation.y = this.yaw;
 
-      // Move the character along the ground plane.
-      this.mesh.position.addScaledVector(direction, moveAmount);
+      // Rotate the local direction by the player's yaw so the mesh moves in the
+      // direction it is facing. This makes strafing respect the current turn.
+      const worldDirection = scratchWorldDirection
+        .copy(direction)
+        .applyAxisAngle(WORLD_UP, this.yaw);
 
-      // In the future this is where collision detection would be applied.
+      this.mesh.position.addScaledVector(
+        worldDirection,
+        this.speed * deltaTime
+      );
     }
 
-    // Keep the camera following behind the player.
+    // --- Camera follow ----------------------------------------------------
     if (this.camera) {
+      // Take the desired camera offset, rotate it so it sits behind the player
+      // relative to their yaw, then position the camera there.
       const offset = scratchCameraOffset
-        .copy(this.options.cameraOffset)
-        .applyAxisAngle(WORLD_UP, this.mesh.rotation.y);
+        .copy(this.cameraOffset)
+        .applyAxisAngle(WORLD_UP, this.yaw);
 
       this.camera.position.copy(this.mesh.position).add(offset);
-      // Look at a point slightly above the character so we see their body.
+
+      // Look slightly above the character so we see their entire body.
       const lookTarget = scratchLookTarget
         .copy(this.mesh.position)
         .addScaledVector(WORLD_UP, 1);
       this.camera.lookAt(lookTarget);
     }
-
-    // sunDir is accepted so lighting-based effects can be added later without
-    // changing the method signature. For now it is not used.
   }
 }


### PR DESCRIPTION
## Summary
- replace the placeholder main character controller with a commented, beginner-friendly version that supports WASD and arrow key movement
- smooth the player's movement, rotation, and camera follow behaviour while keeping configuration simple
- integrate the controller into the main render loop so the camera tracks the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0781d07cc83279ea68472552a4474