### PR TITLE
Add raycasting interactions and crosshair overlay

### DIFF
--- a/src/world/interactions.js
+++ b/src/world/interactions.js
@@ -1,0 +1,120 @@
+import * as THREE from "three";
+
+/**
+ * Create a simple helper that lets us cast rays from the camera into the scene.
+ * Raycasters are how we "pick" objects in three.js – we shoot an invisible ray
+ * and see what it hits first. Beginners can imagine it like a laser pointer.
+ *
+ * @param {THREE.WebGLRenderer} renderer - The renderer so we can read the canvas size.
+ * @param {THREE.Camera} camera - The active camera that defines the view.
+ * @param {THREE.Scene} scene - The scene graph containing objects to test against.
+ * @returns {{
+ *   raycaster: THREE.Raycaster,
+ *   mouse: THREE.Vector2,
+ *   pickObject: (screenX: number, screenY: number) => THREE.Intersection | null,
+ *   pickCenter: () => THREE.Intersection | null,
+ *   updateHover: (object: THREE.Object3D | null) => void,
+ *   clearHover: () => void,
+ *   getCurrentHover: () => THREE.Object3D | null
+ * }}
+ */
+export function createInteractor(renderer, camera, scene) {
+  const raycaster = new THREE.Raycaster();
+  const mouse = new THREE.Vector2();
+
+  const HOVER_COLOR = 0x222244;
+  const storedEmissive = new Map();
+  let currentHover = null;
+
+  /**
+   * Helper that gathers all materials on the object (meshes may have an array).
+   * @param {THREE.Object3D} object
+   * @returns {THREE.Material[]}
+   */
+  function getMaterials(object) {
+    if (!object || !object.material) return [];
+    return Array.isArray(object.material) ? object.material : [object.material];
+  }
+
+  /**
+   * Restore emissive colors for the previously hovered object.
+   */
+  function clearHover() {
+    if (!currentHover) return;
+    for (const material of getMaterials(currentHover)) {
+      if (material && material.emissive && storedEmissive.has(material)) {
+        material.emissive.copy(storedEmissive.get(material));
+        storedEmissive.delete(material);
+      }
+    }
+    currentHover = null;
+  }
+
+  /**
+   * Apply a subtle emissive highlight to the hovered object.
+   * @param {THREE.Object3D | null} object
+   */
+  function updateHover(object) {
+    if (object === currentHover) return;
+    clearHover();
+    if (!object) return;
+
+    for (const material of getMaterials(object)) {
+      if (!material || !material.emissive) continue;
+      if (!storedEmissive.has(material)) {
+        storedEmissive.set(material, material.emissive.clone());
+      }
+      material.emissive.setHex(HOVER_COLOR);
+    }
+    currentHover = object;
+  }
+
+  /**
+   * Convert a screen-space coordinate to normalized device coordinates (NDC)
+   * and cast a ray to find the closest intersected object.
+   *
+   * @param {number} screenX - Pixel X coordinate relative to the canvas.
+   * @param {number} screenY - Pixel Y coordinate relative to the canvas.
+   * @returns {THREE.Intersection | null}
+   */
+  function pickObject(screenX, screenY) {
+    const width = renderer.domElement.clientWidth;
+    const height = renderer.domElement.clientHeight;
+    if (width === 0 || height === 0) return null;
+
+    const xNdc = (screenX / width) * 2 - 1;
+    const yNdc = -(screenY / height) * 2 + 1;
+
+    mouse.set(xNdc, yNdc);
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObjects(scene.children, true);
+    return intersects.length > 0 ? intersects[0] : null;
+  }
+
+  /**
+   * Convenience for casting a ray straight through the center of the screen.
+   * This is perfect for a first-person "crosshair" style interaction.
+   *
+   * @returns {THREE.Intersection | null}
+   */
+  function pickCenter() {
+    mouse.set(0, 0);
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObjects(scene.children, true);
+    return intersects.length > 0 ? intersects[0] : null;
+  }
+
+  function getCurrentHover() {
+    return currentHover;
+  }
+
+  return {
+    raycaster,
+    mouse,
+    pickObject,
+    pickCenter,
+    updateHover,
+    clearHover,
+    getCurrentHover,
+  };
+}

--- a/src/world/ui/crosshair.css
+++ b/src/world/ui/crosshair.css
@@ -1,0 +1,22 @@
+.crosshair-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.crosshair-overlay::before {
+  content: "";
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+}

--- a/src/world/ui/crosshair.js
+++ b/src/world/ui/crosshair.js
@@ -1,0 +1,15 @@
+import "./crosshair.css";
+
+/**
+ * Injects a tiny crosshair element so the player can see where they are aiming.
+ * We only create it once, even if attachCrosshair is called multiple times.
+ */
+export function attachCrosshair() {
+  if (document.querySelector(".crosshair-overlay")) {
+    return;
+  }
+
+  const crosshair = document.createElement("div");
+  crosshair.className = "crosshair-overlay";
+  document.body.appendChild(crosshair);
+}


### PR DESCRIPTION
## Summary
- add a reusable interactor helper for raycasting picks and hover highlighting
- render a lightweight crosshair overlay to show the aim point
- integrate center-screen picking and basic click feedback into the main loop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e225fb21208327bbb6e14ca187eeec