### PR TITLE
Add interactable examples and landmark interaction metadata

### DIFF
--- a/src/world/interactions.js
+++ b/src/world/interactions.js
@@ -56,12 +56,19 @@ export function createInteractor(renderer, camera, scene) {
     return Array.isArray(object.material) ? object.material : [object.material];
   }
 
+  function getHighlightTarget(object) {
+    if (!object) return object;
+    const target = object.userData?.highlightTarget;
+    return target || object;
+  }
+
   /**
    * Restore material colors/emissive values for the previously hovered object.
    */
   function clearHover() {
     if (!currentHover) return;
-    for (const material of getMaterials(currentHover)) {
+    const target = getHighlightTarget(currentHover);
+    for (const material of getMaterials(target)) {
       if (!material || !storedMaterialState.has(material)) continue;
       const stored = storedMaterialState.get(material);
       if (material.emissive && stored.emissive) {
@@ -83,7 +90,8 @@ export function createInteractor(renderer, camera, scene) {
    * @param {THREE.Object3D} object
    */
   function applyHighlight(object) {
-    for (const material of getMaterials(object)) {
+    const target = getHighlightTarget(object);
+    for (const material of getMaterials(target)) {
       if (!material) continue;
 
       if (!storedMaterialState.has(material)) {

--- a/src/world/landmarks.js
+++ b/src/world/landmarks.js
@@ -112,6 +112,15 @@ export async function loadLandmark(scene, url, options = {}) {
       return null;
     }
 
+    root.userData = root.userData || {};
+    root.userData.interactable = root.userData.interactable ?? true;
+    if (typeof root.userData.onUse !== "function") {
+      root.userData.onUse = () => {
+        const label = root.name || url;
+        console.log("Used", label);
+      };
+    }
+
     scene.add(root);
     entry.object = root;
 


### PR DESCRIPTION
## Summary
- add default interaction metadata to loaded landmarks so they respond to use events
- replace the basic cones in the demo scene with a door and lamp interaction example
- allow interactables to define a highlight target for better hover feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e22ef723cc83278acf8e883487a10e