### PR TITLE
Add stubbed input, environment, and player controller modules

### DIFF
--- a/src/controls/PlayerController.ts
+++ b/src/controls/PlayerController.ts
@@ -1,0 +1,24 @@
+// Stub PlayerController – logic will be added in Step 5
+import * as THREE from 'three';
+import type { InputMap } from '../input/InputMap';
+import type { EnvironmentCollider } from '../env/EnvironmentCollider';
+
+export interface PlayerOptions {
+  height?: number;
+  radius?: number;
+  camera?: THREE.Camera;
+}
+
+export class PlayerController {
+  public object = new THREE.Object3D();
+
+  constructor(
+    _input: InputMap,
+    _env: EnvironmentCollider,
+    _opts: PlayerOptions = {}
+  ) {}
+
+  get position() { return this.object.position; }
+  update(_dt: number) {}
+}
+export default PlayerController;

--- a/src/env/EnvironmentCollider.ts
+++ b/src/env/EnvironmentCollider.ts
@@ -1,0 +1,20 @@
+// Stub EnvironmentCollider – logic will be added in Step 4
+import * as THREE from 'three';
+
+export class EnvironmentCollider {
+  public mesh: THREE.Mesh;
+
+  constructor() {
+    this.mesh = new THREE.Mesh(
+      new THREE.BufferGeometry(),
+      new THREE.MeshBasicMaterial({ visible: false })
+    );
+    this.mesh.frustumCulled = false;
+    this.mesh.matrixAutoUpdate = false;
+  }
+
+  fromStaticScene(_root: THREE.Object3D, _opts: { debug?: boolean } = {}) {
+    // Implementation to come (BVH + merge)
+  }
+}
+export default EnvironmentCollider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from './input/InputMap';
+export * from './env/EnvironmentCollider';
+export * from './controls/PlayerController';

--- a/src/input/InputMap.ts
+++ b/src/input/InputMap.ts
@@ -1,0 +1,18 @@
+// Stub InputMap – logic will be added in Step 3
+export class InputMap {
+  private keys = new Set<string>();
+  public pointerLocked = false;
+
+  constructor(_canvas: HTMLCanvasElement | null = null) {}
+  onLook(_dx: number, _dy: number) {}
+  isDown(_code: string) { return false; }
+
+  // convenience getters
+  get forward() { return false; }
+  get back()    { return false; }
+  get left()    { return false; }
+  get right()   { return false; }
+  get sprint()  { return false; }
+  get jump()    { return false; }
+}
+export default InputMap;

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,14 @@
 // main.js
 
+// BEGIN temporary compile check imports
+import { InputMap } from "./input/InputMap";
+import { EnvironmentCollider } from "./env/EnvironmentCollider";
+import { PlayerController } from "./controls/PlayerController";
+void InputMap;
+void EnvironmentCollider;
+void PlayerController;
+// END temporary compile check imports
+
 import * as THREE from "three";
 import { createSky, updateSky, createStars, updateStars } from "./world/sky.js";
 import { createLighting, updateLighting, createMoon, updateMoon } from "./world/lighting.js";


### PR DESCRIPTION
## Summary
- add stub TypeScript modules for input handling, environment collision, and player control
- expose new stubs through a barrel index and add temporary compile-check imports in the main entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e24f94d50c83279d93f7f24b51968a