### PR TITLE
Update deploy workflow to use docs output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,12 +36,12 @@ jobs:
       # Optional: SPA fallback so deep links work on GH Pages
       - name: Add 404 fallback
         run: |
-          if [ -f dist/index.html ]; then cp dist/index.html dist/404.html; fi
+          if [ -f docs/index.html ]; then cp docs/index.html docs/404.html; fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: docs
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- update the SPA 404 fallback to copy from docs output
- upload the docs directory as the pages artifact
- replace remaining dist references with docs for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e25934cb9c8327a25fc467612b63f8