### PR TITLE
Handle varying Vite output directories in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,15 +33,29 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Detect build output directory
+        id: detect-build-dir
+        run: |
+          if [ -f dist/index.html ]; then
+            echo "dir=dist" >> "$GITHUB_OUTPUT"
+          elif [ -f docs/index.html ]; then
+            echo "dir=docs" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unable to locate build output (expected dist/ or docs/)" >&2
+            exit 1
+          fi
+
       # Optional: SPA fallback so deep links work on GH Pages
       - name: Add 404 fallback
+        env:
+          BUILD_DIR: ${{ steps.detect-build-dir.outputs.dir }}
         run: |
-          if [ -f docs/index.html ]; then cp docs/index.html docs/404.html; fi
+          if [ -f "$BUILD_DIR/index.html" ]; then cp "$BUILD_DIR/index.html" "$BUILD_DIR/404.html"; fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: ${{ steps.detect-build-dir.outputs.dir }}
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ glTF/glb assets before importing them into the project.
 This project deploys automatically on push to `main` using GitHub Actions.
 
 - Vite `base` is set to `/athens-game-starter/` in `vite.config.ts` (required for GH Pages).
-- Workflow: `.github/workflows/deploy.yml` builds and publishes `dist` to GitHub Pages.
+- Workflow: `.github/workflows/deploy.yml` builds with Vite and publishes whichever output directory is produced
+  (`dist/` or `docs/`) to GitHub Pages.
 - SPA fallback: `404.html` is copied from `index.html` during the workflow to support deep links.
 
 After the first successful run, the site will be available at:


### PR DESCRIPTION
## Summary
- detect whether Vite emitted a dist/ or docs/ directory before publishing GitHub Pages artifacts
- reuse the detected output directory for the SPA 404 fallback copy and artifact upload steps
- clarify the README to note that the workflow publishes whichever directory Vite produces

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e259f5ea64832793523abeb4d5cd9f