### PR TITLE
Remove Parthenon binary asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 public/basis/
+public/models/buildings/*.glb

--- a/src/buildings/BuildingManager.ts
+++ b/src/buildings/BuildingManager.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import type { EnvironmentCollider } from '../env/EnvironmentCollider';
+
+export class BuildingManager {
+  private loader = new GLTFLoader();
+  constructor(private envCollider: EnvironmentCollider) {}
+
+  async loadBuilding(
+    url: string,
+    options?: {
+      position?: THREE.Vector3;
+      scale?: number;
+      rotateY?: number;
+      collision?: boolean;
+    }
+  ) {
+    const gltf = await this.loader.loadAsync(url);
+    const obj = gltf.scene;
+    if (options?.scale) obj.scale.setScalar(options.scale);
+    if (options?.rotateY) obj.rotation.y = options.rotateY;
+    if (options?.position) obj.position.copy(options.position);
+
+    const parent = this.envCollider.mesh.parent;
+    if (parent) {
+      parent.add(obj);
+    } else {
+      this.envCollider.mesh.add(obj);
+    }
+
+    if (options?.collision) {
+      obj.traverse((child: any) => {
+        if (child.isMesh) {
+          child.userData.noCollision = false;
+        }
+      });
+      this.envCollider.fromStaticScene(this.envCollider.mesh.parent ?? this.envCollider.mesh);
+    } else {
+      obj.traverse((child: any) => {
+        if (child.isMesh) {
+          child.userData.noCollision = true;
+        }
+      });
+    }
+
+    return obj;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { createTerrain, updateTerrain } from "./world/terrain.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { InputMap } from "./input/InputMap";
 import { EnvironmentCollider } from "./env/EnvironmentCollider";
+import { BuildingManager } from "./buildings/BuildingManager";
 import { PlayerController } from "./controls/PlayerController";
 import { Character } from "./characters/Character";
 
@@ -146,6 +147,7 @@ async function init() {
 
   const input = new InputMap(renderer.domElement);
   const envCollider = new EnvironmentCollider();
+  scene.add(envCollider.mesh);
   const player = new PlayerController(input, envCollider, { camera });
   scene.add(player.object);
 
@@ -156,6 +158,25 @@ async function init() {
     renderer
   );
   player.attachCharacter(character);
+
+  const buildingMgr = new BuildingManager(envCollider);
+
+  try {
+    await buildingMgr.loadBuilding(
+      `${import.meta.env.BASE_URL}models/buildings/parthenon.glb`,
+      {
+        scale: 1.5,
+        position: new THREE.Vector3(0, 0, -20),
+        rotateY: Math.PI / 4,
+        collision: true,
+      }
+    );
+  } catch (error) {
+    console.warn(
+      "Parthenon model failed to load. Add the asset to public/models/buildings/ to display it.",
+      error
+    );
+  }
 
   const interactor = createInteractor(renderer, camera, scene);
 


### PR DESCRIPTION
## Summary
- ignore committed building GLB assets so binary models stay out of the repo
- handle missing Parthenon model gracefully during scene setup
- remove the previously committed Parthenon GLB from version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e263e9c2dc8327bcc290c3562512a2