### PR TITLE
Add building manager to load environment structures

### DIFF
--- a/public/models/buildings/README.md
+++ b/public/models/buildings/README.md
@@ -1,0 +1,3 @@
+# Building Models
+
+Add GLB building assets (e.g., Parthenon) to this directory.

--- a/src/buildings/BuildingManager.ts
+++ b/src/buildings/BuildingManager.ts
@@ -21,20 +21,18 @@ export class BuildingManager {
     if (options?.rotateY) obj.rotation.y = options.rotateY;
     if (options?.position) obj.position.copy(options.position);
 
-    const parent = this.envCollider.mesh.parent;
-    if (parent) {
-      parent.add(obj);
-    } else {
-      this.envCollider.mesh.add(obj);
-    }
+    // Add to scene
+    this.envCollider.mesh.parent?.add(obj);
 
+    // If collision desired, mark meshes
     if (options?.collision) {
       obj.traverse((child: any) => {
         if (child.isMesh) {
           child.userData.noCollision = false;
         }
       });
-      this.envCollider.fromStaticScene(this.envCollider.mesh.parent ?? this.envCollider.mesh);
+      // Rebuild the collider from static scene
+      this.envCollider.fromStaticScene(this.envCollider.mesh.parent!);
     } else {
       obj.traverse((child: any) => {
         if (child.isMesh) {


### PR DESCRIPTION
## Summary
- add a BuildingManager helper to load GLB building models into the scene and optionally rebuild collisions
- add a placeholder directory for building assets so Parthenon and other structures can be added under public/models/buildings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e26898a0108327aa4f0958d615d546