### PR TITLE
Load Vite entry module from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   <body>
     <div id="app"></div>
     <!-- Let Vite inject the correct script -->
-    <script type="module"></script>
+    <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- point the module script in `index.html` to `/src/main.js` so Vite boots the Three.js app on load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2c87cf4a483278a41108a4b9161ae