### PR TITLE
Generate favicon during install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 public/basis/
 public/models/buildings/*.glb
+public/favicon.ico

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <title>Athens Game Starter</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build && node scripts/ensure-three-bundled.mjs",
     "preview": "vite preview --strictPort",
-    "typecheck": "tsc -p . || true"
+    "typecheck": "tsc -p . || true",
+    "generate:favicon": "node scripts/generate-favicon.mjs",
+    "postinstall": "npm run generate:favicon"
   },
   "dependencies": {
     "three": "^0.160.0"

--- a/scripts/generate-favicon.mjs
+++ b/scripts/generate-favicon.mjs
@@ -1,0 +1,22 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const base64Icon = `AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAbOmb/Gzpm///XXv//117//9de///XXv//117//9de///XXv//117//9de///XXv//117/Gzpm/xs6Zv8bOmb//9de///XXv//117//9de///XXv//117//9de///XXv//117//9de///XXv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv//117//9de///XXv//117//9de///XXv//117//9de///XXv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb//9de///XXv//117//9de///XXv//117//9de///XXv//117/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv//117//9de///XXv//117//9de///XXv//117//9de/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb//9de///XXv//117//9de///XXv//117//9de/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv//117//9de///XXv//117//9de///XXv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb//9de///XXv//117//9de///XXv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv//117//9de///XXv//117/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb//9de///XXv//117/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv//117//9de/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb//9de/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm///XXv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/Gzpm/xs6Zv8bOmb/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==`;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const faviconPath = resolve(__dirname, '../public/favicon.ico');
+
+const run = async () => {
+  await mkdir(dirname(faviconPath), { recursive: true });
+  const buffer = Buffer.from(base64Icon, 'base64');
+  await writeFile(faviconPath, buffer);
+  console.log(`Generated favicon at ${faviconPath}`);
+};
+
+run().catch((error) => {
+  console.error('Failed to generate favicon.ico', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- ignore the generated favicon binary so the repository stays binary-free
- add a Node script and npm hook to regenerate public/favicon.ico from embedded base64 data when dependencies install

## Testing
- npm run generate:favicon
- npm run dev -- --host 0.0.0.0 --port 4173
- curl -I http://127.0.0.1:4173/athens-game-starter/favicon.ico

------
https://chatgpt.com/codex/tasks/task_b_68e2ca53d3b08327b0fb690d43d30027