### PR TITLE
Strip collider geometries down to positions before merging

### DIFF
--- a/src/env/EnvironmentCollider.ts
+++ b/src/env/EnvironmentCollider.ts
@@ -68,6 +68,13 @@ export class EnvironmentCollider {
       if (!mesh.visible) return;
 
       const cloned = geometry.clone();
+
+      Object.keys(cloned.attributes).forEach((attrName) => {
+        if (attrName !== 'position') {
+          cloned.deleteAttribute(attrName);
+        }
+      });
+
       cloned.applyMatrix4(mesh.matrixWorld);
       geometries.push(cloned);
     });


### PR DESCRIPTION
## Summary
- remove all non-position attributes from cloned meshes before merging collider geometry to avoid attribute mismatches
- ensure merged geometry still retains index data for correct collision triangles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2d7667c7c83278e25d2a4429427b7