### PR TITLE
Integrate Aristotle's Tomb asset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ hosting on GitHub Pages or any static site provider.
 > imports bare modules (such as `three`) and TypeScript entry points that must be
 > processed by Vite before they can run in the browser.
 
+### Downloading Aristotle's Tomb
+
+The main scene now features Aristotle's Tomb from Sketchfab. Because the model
+is distributed under a free license, you still need a Sketchfab API token to
+pull the binary. Run the helper script and pass your token via the environment:
+
+```bash
+SKETCHFAB_TOKEN=<your token> npm run download:aristotle
+```
+
+The GLB is saved to `public/models/buildings/aristotle-tomb.glb`. If the file is
+missing when the app boots the code falls back to the existing Akropol model,
+so you can continue exploring even before fetching the new landmark.
+
 ## KTX2 textures
 
 Models loaded through `GLTFLoader` expect textures in the KTX2 (Basis Universal)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview --strictPort",
     "typecheck": "tsc -p . || true",
     "generate:favicon": "node scripts/generate-favicon.mjs",
+    "download:aristotle": "node scripts/download-aristotle-tomb.mjs",
     "postinstall": "npm run generate:favicon"
   },
   "dependencies": {

--- a/public/models/buildings/README.md
+++ b/public/models/buildings/README.md
@@ -1,3 +1,12 @@
 # Building Models
 
 Add GLB building assets (e.g., Parthenon) to this directory.
+
+To pull the "Aristotle's Tomb" landmark from Sketchfab run:
+
+```
+SKETCHFAB_TOKEN=<your token> npm run download:aristotle
+```
+
+The script writes `aristotle-tomb.glb` into this folder so the game can load it
+at runtime. Tokens are available from https://sketchfab.com/settings/password.

--- a/scripts/download-aristotle-tomb.mjs
+++ b/scripts/download-aristotle-tomb.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const MODEL_UID = '2e13d16efef94632a478afb2efb39704';
+const DESTINATION = path.join('public', 'models', 'buildings', 'aristotle-tomb.glb');
+
+async function downloadTomb() {
+  const token = process.env.SKETCHFAB_TOKEN;
+  if (!token) {
+    console.error('Missing SKETCHFAB_TOKEN environment variable.');
+    console.error('Create a Sketchfab API token and export SKETCHFAB_TOKEN before running this script.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const downloadEndpoint = `https://api.sketchfab.com/v3/models/${MODEL_UID}/download`;
+  const response = await fetch(downloadEndpoint, {
+    headers: {
+      Authorization: `Token ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Sketchfab download API failed (${response.status} ${response.statusText}): ${body}`);
+  }
+
+  const payload = await response.json();
+  const glbTarget = payload.glb ?? payload.gltf;
+  if (!glbTarget?.url) {
+    throw new Error('Download API response did not include a GLB URL.');
+  }
+
+  console.log('Downloading Aristotle\'s Tomb GLB from', glbTarget.url);
+  const assetResponse = await fetch(glbTarget.url, { redirect: 'follow' });
+  if (!assetResponse.ok) {
+    const body = await assetResponse.text();
+    throw new Error(`Failed to download GLB asset (${assetResponse.status} ${assetResponse.statusText}): ${body}`);
+  }
+
+  const arrayBuffer = await assetResponse.arrayBuffer();
+  const destinationDir = path.dirname(DESTINATION);
+  await fs.mkdir(destinationDir, { recursive: true });
+  await fs.writeFile(DESTINATION, Buffer.from(arrayBuffer));
+  console.log('Saved Aristotle\'s Tomb to', DESTINATION);
+}
+
+try {
+  await downloadTomb();
+} catch (error) {
+  console.error('Unable to download Aristotle\'s Tomb asset.');
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -166,22 +166,26 @@ async function mainApp() {
   player.attachCharacter(character);
 
   const buildingMgr = new BuildingManager(envCollider);
+  const tombOptions = {
+    scale: 1.2,
+    position: new THREE.Vector3(6, 0, -28),
+    rotateY: Math.PI * 0.15,
+    collision: true,
+  };
+  const buildingBase = `${import.meta.env.BASE_URL}models/buildings/`;
 
   try {
-    await buildingMgr.loadBuilding(
-      `${import.meta.env.BASE_URL}models/buildings/parthenon.glb`,
-      {
-        scale: 1.5,
-        position: new THREE.Vector3(0, 0, -20),
-        rotateY: Math.PI / 4,
-        collision: true,
-      }
-    );
+    await buildingMgr.loadBuilding(`${buildingBase}aristotle-tomb.glb`, tombOptions);
   } catch (error) {
     console.warn(
-      "Parthenon model failed to load. Add the asset to public/models/buildings/ to display it.",
+      "Aristotle's Tomb failed to load. Download it with npm run download:aristotle.",
       error
     );
+    try {
+      await buildingMgr.loadBuilding(`${buildingBase}Akropol.glb`, tombOptions);
+    } catch (fallbackError) {
+      console.error('Akropol fallback model also failed to load.', fallbackError);
+    }
   }
 
   console.log("Scene children:", scene.children);


### PR DESCRIPTION
## Summary
- add an npm script and downloader utility to pull Aristotle's Tomb from Sketchfab with an API token
- document the new workflow and hook the main scene up to load the tomb model with an Akropol fallback

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e2cce7a3c083278dcb71668d1a3267