### PR TITLE
Implement keyboard and pointer lock input handling

### DIFF
--- a/src/input/InputMap.ts
+++ b/src/input/InputMap.ts
@@ -1,18 +1,138 @@
-// Stub InputMap – logic will be added in Step 3
+const MOVEMENT_KEYS = new Set([
+  "KeyW",
+  "KeyA",
+  "KeyS",
+  "KeyD",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ShiftLeft",
+  "ShiftRight",
+  "Space",
+]);
+
+export interface LookDelta {
+  yaw: number;
+  pitch: number;
+}
+
 export class InputMap {
   private keys = new Set<string>();
   public pointerLocked = false;
 
-  constructor(_canvas: HTMLCanvasElement | null = null) {}
-  onLook(_dx: number, _dy: number) {}
-  isDown(_code: string) { return false; }
+  private readonly canvas: HTMLCanvasElement | null;
+  private readonly keyDownHandler = (event: KeyboardEvent) => {
+    this.keys.add(event.code);
+    if (MOVEMENT_KEYS.has(event.code)) {
+      event.preventDefault();
+    }
+  };
+  private readonly keyUpHandler = (event: KeyboardEvent) => {
+    this.keys.delete(event.code);
+    if (MOVEMENT_KEYS.has(event.code)) {
+      event.preventDefault();
+    }
+  };
+  private readonly blurHandler = () => {
+    this.resetKeys();
+  };
+  private readonly pointerMoveHandler = (event: PointerEvent) => {
+    this.onLook(event.movementX, event.movementY);
+  };
+  private readonly pointerLockChangeHandler = () => {
+    const locked = document.pointerLockElement === this.canvas;
+
+    if (locked && !this.pointerLocked) {
+      document.addEventListener("pointermove", this.pointerMoveHandler);
+    } else if (!locked && this.pointerLocked) {
+      document.removeEventListener("pointermove", this.pointerMoveHandler);
+      this.resetLookDelta();
+    }
+
+    this.pointerLocked = locked;
+  };
+
+  private lookYaw = 0;
+  private lookPitch = 0;
+
+  constructor(canvas: HTMLCanvasElement | null = null) {
+    this.canvas = canvas;
+
+    window.addEventListener("keydown", this.keyDownHandler);
+    window.addEventListener("keyup", this.keyUpHandler);
+    window.addEventListener("blur", this.blurHandler);
+    window.addEventListener("focus", this.blurHandler);
+    document.addEventListener("pointerlockchange", this.pointerLockChangeHandler);
+  }
+
+  dispose() {
+    window.removeEventListener("keydown", this.keyDownHandler);
+    window.removeEventListener("keyup", this.keyUpHandler);
+    window.removeEventListener("blur", this.blurHandler);
+    window.removeEventListener("focus", this.blurHandler);
+    document.removeEventListener("pointerlockchange", this.pointerLockChangeHandler);
+    document.removeEventListener("pointermove", this.pointerMoveHandler);
+  }
+
+  requestPointerLock() {
+    this.canvas?.requestPointerLock?.();
+  }
+
+  releasePointerLock() {
+    if (document.pointerLockElement === this.canvas) {
+      document.exitPointerLock?.();
+    }
+  }
+
+  onLook(dx: number, dy: number) {
+    const sensitivity = 0.0025;
+    this.lookYaw += dx * sensitivity;
+    this.lookPitch += dy * sensitivity;
+  }
+
+  consumeLookDelta(): LookDelta {
+    const yaw = this.lookYaw;
+    const pitch = this.lookPitch;
+    this.resetLookDelta();
+    return { yaw, pitch };
+  }
+
+  get yawDelta() { return this.lookYaw; }
+  get pitchDelta() { return this.lookPitch; }
+
+  isDown(code: string) {
+    return this.keys.has(code);
+  }
 
   // convenience getters
-  get forward() { return false; }
-  get back()    { return false; }
-  get left()    { return false; }
-  get right()   { return false; }
-  get sprint()  { return false; }
-  get jump()    { return false; }
+  get forward() {
+    return this.isDown("KeyW") || this.isDown("ArrowUp");
+  }
+  get back() {
+    return this.isDown("KeyS") || this.isDown("ArrowDown");
+  }
+  get left() {
+    return this.isDown("KeyA") || this.isDown("ArrowLeft");
+  }
+  get right() {
+    return this.isDown("KeyD") || this.isDown("ArrowRight");
+  }
+  get sprint() {
+    return this.isDown("ShiftLeft") || this.isDown("ShiftRight");
+  }
+  get jump() {
+    return this.isDown("Space");
+  }
+
+  private resetKeys() {
+    this.keys.clear();
+  }
+
+  private resetLookDelta() {
+    this.lookYaw = 0;
+    this.lookPitch = 0;
+  }
 }
+
 export default InputMap;

--- a/src/main.js
+++ b/src/main.js
@@ -248,7 +248,10 @@ async function mainApp() {
 
   // Simple controls: clicking the canvas or pressing E will run the onUse
   // callback attached to whatever we are currently looking at.
-  renderer.domElement.addEventListener("pointerdown", () => {
+  renderer.domElement.addEventListener("pointerdown", (event) => {
+    if (event.button === 0 && !input.pointerLocked) {
+      input.requestPointerLock();
+    }
     interactor.useObject();
   });
 


### PR DESCRIPTION
## Summary
- implement the InputMap to track keyboard state, pointer lock, and accumulated look deltas
- request pointer lock from the main render canvas so mouse-look data begins flowing when clicked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2d75524bc8327aef7478cf9e35a89