### PR TITLE
Handle missing hero avatar gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ To run the project locally:
 The build step outputs self-contained static assets under `docs/`, suitable for
 hosting on GitHub Pages or any static site provider.
 
+> ℹ️ Drop a hero character model at `public/models/character/hero.glb` to see the
+> fully animated avatar. When the file is missing the app now spawns a simple
+> fallback capsule so movement and interactions remain testable.
+
 > ⚠️ Opening `index.html` directly from the filesystem will not work. The source
 > imports bare modules (such as `three`) and TypeScript entry points that must be
 > processed by Vite before they can run in the browser.

--- a/src/main.js
+++ b/src/main.js
@@ -157,13 +157,49 @@ async function mainApp() {
   const player = new PlayerController(input, envCollider, { camera });
   scene.add(player.object);
 
+  const createFallbackAvatar = () => {
+    const group = new THREE.Group();
+    group.name = "FallbackAvatar";
+
+    const bodyMaterial = new THREE.MeshStandardMaterial({
+      color: 0x4e8ef7,
+      metalness: 0.2,
+      roughness: 0.6,
+    });
+
+    const body = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.35, 0.35, 1.2, 16),
+      bodyMaterial
+    );
+    body.castShadow = true;
+    body.receiveShadow = true;
+    body.position.y = 0.6;
+    group.add(body);
+
+    const head = new THREE.Mesh(
+      new THREE.SphereGeometry(0.32, 16, 16),
+      new THREE.MeshStandardMaterial({ color: 0xf4f7ff, roughness: 0.4 })
+    );
+    head.castShadow = true;
+    head.position.y = 1.32;
+    group.add(head);
+
+    return group;
+  };
+
   const character = new Character();
-  scene.add(character);
-  await character.load(
-    `${import.meta.env.BASE_URL}models/character/hero.glb`,
-    renderer
-  );
-  player.attachCharacter(character);
+  try {
+    await character.load(
+      `${import.meta.env.BASE_URL}models/character/hero.glb`,
+      renderer
+    );
+    player.attachCharacter(character);
+  } catch (error) {
+    console.warn("Hero character failed to load; using fallback avatar.", error);
+    const fallbackAvatar = createFallbackAvatar();
+    player.object.add(fallbackAvatar);
+    fallbackAvatar.position.set(0, 0, 0);
+  }
 
   const buildingMgr = new BuildingManager(envCollider);
   const tombOptions = {


### PR DESCRIPTION
## Summary
- guard the hero character load with a try/catch so the scene can boot without the GLB
- spawn a simple capsule-based fallback avatar when the real model is unavailable
- document the need to drop `public/models/character/hero.glb` for the full experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e30e9fde008327a760536f83bd4658