### PR TITLE
Add import map for three to support static hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <title>Athens Game Starter</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://esm.sh/three@0.160.0",
+          "three/": "https://esm.sh/three@0.160.0/",
+          "three/examples/": "https://esm.sh/three@0.160.0/examples/"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary
- add an import map that resolves the `three` bare specifier when the site is served without Vite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e31bbb29b08327b18afa4d537f3c20