### PR TITLE
Prevent hero asset probe from accepting HTML fallbacks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,16 +13,21 @@ import { BuildingManager } from "./buildings/BuildingManager";
 import { PlayerController } from "./controls/PlayerController";
 import { Character } from "./characters/Character";
 
+function isHtmlResponse(response) {
+  const contentType = response.headers.get("content-type") || "";
+  return contentType.includes("text/html");
+}
+
 async function probeAsset(url) {
   try {
     const response = await fetch(url, { method: "HEAD" });
-    if (response.ok) {
+    if (response.ok && !isHtmlResponse(response)) {
       return true;
     }
 
     if (response.status === 405 || response.status === 501) {
       const getResponse = await fetch(url, { method: "GET" });
-      return getResponse.ok;
+      return getResponse.ok && !isHtmlResponse(getResponse);
     }
 
     return false;


### PR DESCRIPTION
## Summary
- avoid treating HTML fallback pages as valid hero assets when probing for models
- ensure the hero loader falls back to the placeholder avatar when the GLB is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e31f519d348327a09b7acbfa9172a1