### PR TITLE
Ignore sky dome in environment collisions

### DIFF
--- a/src/world/sky.js
+++ b/src/world/sky.js
@@ -10,6 +10,11 @@ export function createSky(scene) {
   // Build and configure the sky dome shader.
   const sky = new Sky();
   sky.scale.setScalar(450000); // make it very big
+  // Mark the sky dome as non-collidable so it is ignored when building
+  // the environment collider. Otherwise the huge sphere would be merged
+  // into the collision geometry and the player capsule would constantly
+  // intersect it, preventing movement.
+  sky.userData.noCollision = true;
 
   const uniforms = sky.material.uniforms;
   uniforms.turbidity.value = 10;


### PR DESCRIPTION
## Summary
- mark the sky dome as non-collidable so the environment collider ignores it and the player can move freely

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e385394c608327ad6b125204d596ec