### PR TITLE
Prevent player model from being baked into the environment collider

### DIFF
--- a/src/controls/PlayerController.js
+++ b/src/controls/PlayerController.js
@@ -15,6 +15,7 @@ export class PlayerController {
    */
   constructor(input, env, opts = {}) {
     this.object = new THREE.Object3D();
+    this.object.userData.noCollision = true;
 
     this.moveSpeed = 4.0;
     this.sprintMult = 1.8;

--- a/src/env/EnvironmentCollider.js
+++ b/src/env/EnvironmentCollider.js
@@ -53,12 +53,23 @@ export class EnvironmentCollider {
     const material = this.mesh.material;
     material.visible = !!opts.debug;
 
+    const shouldInclude = (node) => {
+      let current = node;
+      while (current) {
+        if (current.userData?.noCollision === true) {
+          return false;
+        }
+        current = current.parent;
+      }
+      return true;
+    };
+
     root.traverse((child) => {
       if (!child.isMesh) return;
       if (child === this.mesh) return;
 
       const mesh = child;
-      if (mesh.userData?.noCollision === true) return;
+      if (!shouldInclude(mesh)) return;
       const geometry = mesh.geometry;
       if (!geometry || !geometry.attributes.position) return;
       if (!mesh.visible) return;


### PR DESCRIPTION
## Summary
- mark the player controller root object as non-collidable so the environment collider ignores runtime avatars
- ensure the environment collider skips any mesh whose ancestors disable collision when rebuilding the static mesh

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e388c5bf448327aa0b5cfd41954a44