### PR TITLE
Improve asset fallbacks for missing hero and tomb models

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ hosting on GitHub Pages or any static site provider.
 
 > ℹ️ The repository intentionally omits large binary assets. Drop a hero
 > character model at `public/models/character/hero.glb` to see the fully animated
-> avatar. When the file is missing the app spawns a simple fallback capsule so
-> movement and interactions remain testable.
+> avatar. When the file is missing the runtime first tries the bundled
+> "Hooded Adventurer" sample before falling back to a simple capsule so movement
+> and interactions remain testable.
 
 > ⚠️ Opening `index.html` directly from the filesystem will not work. The source
 > imports bare modules (such as `three`) and TypeScript entry points that must be
@@ -30,8 +31,9 @@ SKETCHFAB_TOKEN=<your token> npm run download:aristotle
 ```
 
 The GLB is saved to `public/models/buildings/aristotle-tomb.glb`. If the file is
-missing when the app boots the runtime now spawns a lightweight placeholder
-monument so you can continue exploring even before fetching the premium asset.
+missing when the app boots the runtime now renders a bundled placeholder glTF
+and, when that is not available, spawns a lightweight procedural monument so you
+can continue exploring even before fetching the premium asset.
 
 ## KTX2 textures
 


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve the first available asset URL at runtime
- load the bundled “Hooded Adventurer” sample avatar when hero.glb is absent and prioritise the downloaded tomb GLB before the placeholder
- document the updated fallback behaviour for character and landmark assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3979cec408327af5845fec7e6055a