### PR TITLE
Reduce per-frame logging in animation loop

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -405,30 +405,12 @@ async function mainApp() {
     await loadFallbackMonument();
   }
 
-  console.log("Scene children:", scene.children);
-  scene.traverse((obj) => {
-    console.log(
-      "Object:",
-      obj.name || obj.type,
-      "pos",
-      obj.position?.toArray ? obj.position.toArray() : obj.position
-    );
-  });
-
   const interactor = createInteractor(renderer, camera, scene);
 
   const clock = new THREE.Clock();
   const dayDuration = 60; // seconds for full cycle
 
-  let frameCount = 0;
   function animate() {
-    frameCount += 1;
-    if (frameCount === 1) {
-      console.log("🌀 Entered render loop");
-    }
-    if (frameCount % 60 === 0) {
-      console.log("⏱ frame", frameCount);
-    }
     requestAnimationFrame(animate);
 
     // Keep track of time for smooth animation and frame-independent movement.


### PR DESCRIPTION
## Summary
- remove scene traversal logging that ran before entering the render loop
- eliminate frame-count based logging from the requestAnimationFrame handler to lower per-frame overhead

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e399b8aec08327a7c6277204627dda