### PR TITLE
Prevent moon collider from trapping the player near spawn

### DIFF
--- a/src/world/lighting.js
+++ b/src/world/lighting.js
@@ -95,6 +95,11 @@ export function createMoon(scene) {
 
   // Group keeps the light and mesh moving together around the world.
   const group = new Group();
+  // Flag the moon group as non-collidable so the environment collider ignores
+  // the temporary origin position before the animation loop relocates it.
+  // Otherwise the initial collider bake would merge the sphere geometry and
+  // the player capsule would immediately intersect it, preventing movement.
+  group.userData.noCollision = true;
   group.add(light);
   group.add(mesh);
 


### PR DESCRIPTION
## Summary
- mark the moon's scene group as non-collidable before baking environment collisions
- avoid merging the temporary origin-bound moon mesh into the collider, which trapped the capsule at spawn

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e39df6ba5c83279be9681aeb2963b0