### PR TITLE
Ensure hero GLB can be published via GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/basis/
 public/models/buildings/*.glb
 public/favicon.ico
 docs/models/**/*.glb
+!docs/models/character/hero.glb

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ To run the project locally:
 The build step outputs self-contained static assets under `docs/`, suitable for
 hosting on GitHub Pages or any static site provider.
 
-> ℹ️ The repository intentionally omits large binary assets. Drop a hero
-> character model at `public/models/character/hero.glb` to see the fully animated
-> avatar. When the file is missing the runtime first tries the bundled
-> "Hooded Adventurer" sample before falling back to a simple capsule so movement
-> and interactions remain testable.
+> ℹ️ Drop a hero character model at `public/models/character/hero.glb` to see the
+> fully animated avatar. When the file is missing the runtime first tries the
+> bundled "Hooded Adventurer" sample before falling back to a simple capsule so
+> movement and interactions remain testable. The build output at
+> `docs/models/character/hero.glb` is tracked by Git so production deployments
+> served from the `docs/` folder (for example GitHub Pages) can fetch the model.
 
 ### Controls
 
@@ -40,9 +41,8 @@ loads your custom `hero.glb`:
    your file it logs a warning about the placeholder capsule; seeing the fully
    animated character without that warning confirms the GLB loaded correctly.
 4. When preparing a production build, make sure the same file ends up at
-   `docs/models/character/hero.glb` so your deployment can fetch it. Hosted
-   services that mirror the repository (such as GitHub Pages) expect the file in
-   that location.
+   `docs/models/character/hero.glb` and commit it. Hosted services that mirror the
+   repository (such as GitHub Pages) expect the file in that location.
 
 > ⚠️ Opening `index.html` directly from the filesystem will not work. The source
 > imports bare modules (such as `three`) and TypeScript entry points that must be

--- a/docs/models/character/README.md
+++ b/docs/models/character/README.md
@@ -2,6 +2,7 @@
 
 The runtime expects a GLB named `hero.glb` in this folder. When you add or update
 the model, run `npm run build` so the asset is copied into
-`docs/models/character/hero.glb` for GitHub Pages. The Git repository ignores the
-binary so history stays reviewable; keep a local copy or rely on your own asset
-pipeline when deploying.
+`docs/models/character/hero.glb` for GitHub Pages. The repository now tracks that
+specific output so deployments served straight from the `docs/` folder (such as
+GitHub Pages) can fetch it. Remember to commit the generated file alongside your
+source asset.

--- a/public/models/character/README.md
+++ b/public/models/character/README.md
@@ -2,6 +2,7 @@
 
 The runtime expects a GLB named `hero.glb` in this folder. When you add or update
 the model, run `npm run build` so the asset is copied into
-`docs/models/character/hero.glb` for GitHub Pages. The Git repository ignores the
-binary so history stays reviewable; keep a local copy or rely on your own asset
-pipeline when deploying.
+`docs/models/character/hero.glb` for GitHub Pages. The repository now tracks that
+specific output so deployments served straight from the `docs/` folder (such as
+GitHub Pages) can fetch it. Remember to commit the generated file alongside your
+source asset.


### PR DESCRIPTION
## Summary
- allow the generated docs/models/character/hero.glb file to be tracked so GitHub Pages can serve the hero model
- clarify the repository documentation so contributors know to commit the copied hero asset for production deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3a4512718832794dfd172f273dbd3