### PR TITLE
feat: replace mouse look with keyboard camera controls

### DIFF
--- a/src/controls/PlayerController.js
+++ b/src/controls/PlayerController.js
@@ -106,7 +106,7 @@ export class PlayerController {
       }
     }
 
-    const lookDelta = this.input.consumeLookDelta();
+    const lookDelta = this.input.consumeLookDelta(dt);
     if (this.camera) {
       this.cameraYaw -= lookDelta.yaw;
       this.cameraPitch -= lookDelta.pitch;

--- a/src/input/InputMap.js
+++ b/src/input/InputMap.js
@@ -1,4 +1,4 @@
-const MOVEMENT_KEYS = new Set([
+const CONTROL_KEYS = new Set([
   "KeyW",
   "KeyA",
   "KeyS",
@@ -26,15 +26,8 @@ export class InputMap {
   constructor(canvas = null) {
     /** @private */
     this.keys = new Set();
-    /** @type {boolean} */
-    this.pointerLocked = false;
     /** @private */
     this.canvas = canvas;
-
-    /** @private */
-    this.lookYaw = 0;
-    /** @private */
-    this.lookPitch = 0;
 
     /** @private */
     this.flyToggleQueued = false;
@@ -45,14 +38,14 @@ export class InputMap {
       if (event.code === "KeyF" && !event.repeat) {
         this.flyToggleQueued = true;
       }
-      if (MOVEMENT_KEYS.has(event.code)) {
+      if (CONTROL_KEYS.has(event.code)) {
         event.preventDefault();
       }
     };
     /** @private */
     this.keyUpHandler = (event) => {
       this.keys.delete(event.code);
-      if (MOVEMENT_KEYS.has(event.code)) {
+      if (CONTROL_KEYS.has(event.code)) {
         event.preventDefault();
       }
     };
@@ -62,28 +55,10 @@ export class InputMap {
       this.flyToggleQueued = false;
     };
     /** @private */
-    this.pointerMoveHandler = (event) => {
-      this.onLook(event.movementX, event.movementY);
-    };
-    /** @private */
-    this.pointerLockChangeHandler = () => {
-      const locked = document.pointerLockElement === this.canvas;
-
-      if (locked && !this.pointerLocked) {
-        document.addEventListener("pointermove", this.pointerMoveHandler);
-      } else if (!locked && this.pointerLocked) {
-        document.removeEventListener("pointermove", this.pointerMoveHandler);
-        this.resetLookDelta();
-      }
-
-      this.pointerLocked = locked;
-    };
-
     window.addEventListener("keydown", this.keyDownHandler);
     window.addEventListener("keyup", this.keyUpHandler);
     window.addEventListener("blur", this.blurHandler);
     window.addEventListener("focus", this.blurHandler);
-    document.addEventListener("pointerlockchange", this.pointerLockChangeHandler);
   }
 
   dispose() {
@@ -91,46 +66,21 @@ export class InputMap {
     window.removeEventListener("keyup", this.keyUpHandler);
     window.removeEventListener("blur", this.blurHandler);
     window.removeEventListener("focus", this.blurHandler);
-    document.removeEventListener("pointerlockchange", this.pointerLockChangeHandler);
-    document.removeEventListener("pointermove", this.pointerMoveHandler);
-  }
-
-  requestPointerLock() {
-    this.canvas?.requestPointerLock?.();
-  }
-
-  releasePointerLock() {
-    if (document.pointerLockElement === this.canvas) {
-      document.exitPointerLock?.();
-    }
   }
 
   /**
-   * @param {number} dx
-   * @param {number} dy
-   */
-  onLook(dx, dy) {
-    const sensitivity = 0.0025;
-    this.lookYaw += dx * sensitivity;
-    this.lookPitch += dy * sensitivity;
-  }
-
-  /**
+   * @param {number} [dt=0]
    * @returns {LookDelta}
    */
-  consumeLookDelta() {
-    const yaw = this.lookYaw;
-    const pitch = this.lookPitch;
-    this.resetLookDelta();
-    return { yaw, pitch };
-  }
+  consumeLookDelta(dt = 0) {
+    const yawInput = (this.lookRight ? 1 : 0) - (this.lookLeft ? 1 : 0);
+    const pitchInput = (this.lookDown ? 1 : 0) - (this.lookUp ? 1 : 0);
+    const sensitivity = 1.8; // radians per second
 
-  get yawDelta() {
-    return this.lookYaw;
-  }
-
-  get pitchDelta() {
-    return this.lookPitch;
+    return {
+      yaw: yawInput * sensitivity * dt,
+      pitch: pitchInput * sensitivity * dt,
+    };
   }
 
   /**
@@ -141,19 +91,19 @@ export class InputMap {
   }
 
   get forward() {
-    return this.isDown("KeyW") || this.isDown("ArrowUp");
+    return this.isDown("KeyW");
   }
 
   get back() {
-    return this.isDown("KeyS") || this.isDown("ArrowDown");
+    return this.isDown("KeyS");
   }
 
   get left() {
-    return this.isDown("KeyA") || this.isDown("ArrowLeft");
+    return this.isDown("KeyA");
   }
 
   get right() {
-    return this.isDown("KeyD") || this.isDown("ArrowRight");
+    return this.isDown("KeyD");
   }
 
   get sprint() {
@@ -172,6 +122,22 @@ export class InputMap {
     return this.isDown("ControlLeft") || this.isDown("ControlRight");
   }
 
+  get lookLeft() {
+    return this.isDown("ArrowLeft");
+  }
+
+  get lookRight() {
+    return this.isDown("ArrowRight");
+  }
+
+  get lookUp() {
+    return this.isDown("ArrowUp");
+  }
+
+  get lookDown() {
+    return this.isDown("ArrowDown");
+  }
+
   consumeFlyToggle() {
     if (!this.flyToggleQueued) return false;
     this.flyToggleQueued = false;
@@ -183,11 +149,6 @@ export class InputMap {
     this.keys.clear();
   }
 
-  /** @private */
-  resetLookDelta() {
-    this.lookYaw = 0;
-    this.lookPitch = 0;
-  }
 }
 
 export default InputMap;

--- a/src/main.js
+++ b/src/main.js
@@ -452,10 +452,9 @@ async function mainApp() {
   // Simple controls: clicking the canvas or pressing E will run the onUse
   // callback attached to whatever we are currently looking at.
   renderer.domElement.addEventListener("pointerdown", (event) => {
-    if (event.button === 0 && !input.pointerLocked) {
-      input.requestPointerLock();
+    if (event.button === 0) {
+      interactor.useObject();
     }
-    interactor.useObject();
   });
 
   window.addEventListener("keydown", (event) => {


### PR DESCRIPTION
## Summary
- remove pointer lock handling so the mouse is no longer required for camera look
- make arrow keys drive the look delta while restricting movement to WASD keys
- update the player controller to consume the new dt-based look delta

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3a4805e248327a6422240fef91ed8