### PR TITLE
Refactor harbor coordinates into shared module

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { attachCrosshair } from "./world/ui/crosshair.js";
 import { createTerrain, updateTerrain } from "./world/terrain.js";
 import { createOcean, updateOcean } from "./world/water.js";
 import { createHarbor } from "./world/harbor.js";
+import { HARBOR_CENTER_3D } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
 import { InputMap } from "./input/InputMap.js";
@@ -140,9 +141,9 @@ async function mainApp() {
   const terrain = createTerrain(scene);
   const ocean = await createOcean(scene, {
     size: 800,
-    position: new THREE.Vector3(-120, 0, 80),
+    position: HARBOR_CENTER_3D.clone(),
   });
-  createHarbor(scene, { center: new THREE.Vector3(-120, 0, 80) });
+  createHarbor(scene, { center: HARBOR_CENTER_3D });
 
   // Lay out a formal civic district with a central promenade, symmetrical
   // civic buildings, and decorative lighting to give the city a planned

--- a/src/world/harbor.js
+++ b/src/world/harbor.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { HARBOR_CENTER_3D } from "./locations.js";
 
 function enableShadows(mesh) {
   mesh.castShadow = true;
@@ -54,7 +55,7 @@ function createCrate(size, material) {
 }
 
 export function createHarbor(scene, options = {}) {
-  const center = options.center ? options.center.clone() : new THREE.Vector3(-120, 0, 80);
+  const center = options.center ? options.center.clone() : HARBOR_CENTER_3D.clone();
   const mainLength = options.mainLength ?? 70;
   const mainWidth = options.mainWidth ?? 9;
   const deckHeight = options.deckHeight ?? 1.4;

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -1,0 +1,5 @@
+import * as THREE from "three";
+
+export const HARBOR_CENTER = new THREE.Vector2(-120, 80);
+export const HARBOR_CENTER_3D = new THREE.Vector3(-120, 0, 80);
+export const HARBOR_SEA_LEVEL = -0.8;

--- a/src/world/terrain.js
+++ b/src/world/terrain.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { HARBOR_CENTER, HARBOR_SEA_LEVEL } from "./locations.js";
 
 // Utility: basic pseudo-random gradient noise using deterministic hashing so we can
 // produce repeatable rolling hills without pulling in an additional dependency.
@@ -58,10 +59,8 @@ function fbm(x, z, octaves, persistence, lacunarity) {
 
 // Cache vector instances so updateTerrain can reuse them without churn.
 const _scratchVec = new THREE.Vector3();
-const HARBOR_CENTER = new THREE.Vector2(-120, 80);
 const HARBOR_INNER_RADIUS = 18;
 const HARBOR_OUTER_RADIUS = 70;
-const HARBOR_SEA_LEVEL = -0.8;
 
 export function createTerrain(scene) {
   // A large subdivided plane gives us enough vertices to push around and create


### PR DESCRIPTION
## Summary
- extract the harbor center and sea level constants into a shared world locations module
- update the terrain, harbor, and main scene setup to consume the shared values so placements stay aligned

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3b79bd9188327b078ea9def264850