### PR TITLE
feat(world): seeded city, harbor instancing, adaptive ocean

### DIFF
--- a/src/world/city.js
+++ b/src/world/city.js
@@ -1,0 +1,232 @@
+import * as THREE from "three";
+import { SEA_LEVEL } from "./locations.js";
+
+const _tempObject = new THREE.Object3D();
+const _tempColor = new THREE.Color();
+
+function createSeededRng(seed = 1) {
+  let h = 0;
+  if (typeof seed === "string") {
+    for (let i = 0; i < seed.length; i++) {
+      h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+    }
+  } else {
+    h = seed >>> 0;
+  }
+  if (h === 0) {
+    h = 0x9e3779b9;
+  }
+  return () => {
+    h ^= h << 13;
+    h ^= h >>> 17;
+    h ^= h << 5;
+    return (h >>> 0) / 0xffffffff;
+  };
+}
+
+function sampleLot(terrain, center, halfWidth, halfDepth) {
+  if (!terrain || !terrain.userData || typeof terrain.userData.getHeightAt !== "function") {
+    return null;
+  }
+  const getHeightAt = terrain.userData.getHeightAt;
+  const corners = [
+    new THREE.Vector2(center.x - halfWidth, center.z - halfDepth),
+    new THREE.Vector2(center.x + halfWidth, center.z - halfDepth),
+    new THREE.Vector2(center.x - halfWidth, center.z + halfDepth),
+    new THREE.Vector2(center.x + halfWidth, center.z + halfDepth),
+    new THREE.Vector2(center.x, center.z),
+  ];
+
+  const heights = [];
+  for (const corner of corners) {
+    const height = getHeightAt(corner.x, corner.z);
+    if (height == null) {
+      return null;
+    }
+    heights.push(height);
+  }
+
+  let min = heights[0];
+  let max = heights[0];
+  let sum = 0;
+  for (const value of heights) {
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+    sum += value;
+  }
+
+  return {
+    height: sum / heights.length,
+    slope: max - min,
+  };
+}
+
+function applyInstanceTransform(instanced, index, position, rotationY, scale) {
+  _tempObject.position.copy(position);
+  _tempObject.rotation.set(0, rotationY, 0);
+  _tempObject.scale.copy(scale);
+  _tempObject.updateMatrix();
+  instanced.setMatrixAt(index, _tempObject.matrix);
+}
+
+function colorFromPalette(rng, palette) {
+  const color = palette[Math.floor(rng() * palette.length)] ?? palette[0];
+  return _tempColor.set(color);
+}
+
+export function createCity(scene, terrain, options = {}) {
+  const group = new THREE.Group();
+  group.name = "HarborCity";
+  scene.add(group);
+
+  const center = options.center ? options.center.clone() : new THREE.Vector3(-70, SEA_LEVEL, 25);
+  const seed = options.seed ?? 2024;
+  const rng = createSeededRng(seed);
+
+  const columns = options.columns ?? 6;
+  const rows = options.rows ?? 5;
+  const spacing = options.spacing ?? 12;
+  const footprintRange = options.footprintRange ?? [6, 9];
+  const depthRange = options.depthRange ?? [6, 10];
+  const heightRange = options.heightRange ?? [4, 9];
+  const roofHeightRange = options.roofHeightRange ?? [0.8, 2.2];
+  const maxSlope = options.maxSlope ?? 1.8;
+
+  const maxInstances = columns * rows;
+  const wallGeometry = new THREE.BoxGeometry(1, 1, 1);
+  const wallMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0xcbb49a),
+    roughness: 0.78,
+    metalness: 0.08,
+  });
+  const wallMesh = new THREE.InstancedMesh(wallGeometry, wallMaterial, maxInstances);
+  wallMesh.castShadow = true;
+  wallMesh.receiveShadow = true;
+  wallMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  wallMesh.userData.noCollision = false;
+
+  const roofGeometry = new THREE.ConeGeometry(1, 1, 4);
+  roofGeometry.rotateY(Math.PI / 4);
+  const roofMaterial = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0x7a422a),
+    roughness: 0.6,
+    metalness: 0.05,
+    emissive: new THREE.Color(0x120600),
+    emissiveIntensity: 0.0,
+  });
+  const roofMesh = new THREE.InstancedMesh(roofGeometry, roofMaterial, maxInstances);
+  roofMesh.castShadow = true;
+  roofMesh.receiveShadow = true;
+  roofMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  roofMesh.userData.noCollision = true;
+
+  const wallPalette = [0xdcc7ae, 0xc5b89f, 0xbda98c, 0xd0c3b1];
+  const roofPalette = [0x884b30, 0x6e3825, 0x9b5733, 0x70422b];
+
+  let instanceIndex = 0;
+  const offsetX = (columns - 1) * spacing * 0.5;
+  const offsetZ = (rows - 1) * spacing * 0.5;
+
+  const position = new THREE.Vector3();
+  const scale = new THREE.Vector3();
+  let accumulatedHeight = 0;
+  let sampledLots = 0;
+
+  for (let ix = 0; ix < columns; ix++) {
+    for (let iz = 0; iz < rows; iz++) {
+      const lotCenterX = center.x + ix * spacing - offsetX;
+      const lotCenterZ = center.z + iz * spacing - offsetZ;
+
+      const footprint = THREE.MathUtils.lerp(footprintRange[0], footprintRange[1], rng());
+      const depth = THREE.MathUtils.lerp(depthRange[0], depthRange[1], rng());
+      const rotationY = Math.round(rng()) * (Math.PI / 2);
+
+      position.set(lotCenterX, 0, lotCenterZ);
+      const sample = sampleLot(terrain, position, footprint * 0.5, depth * 0.5);
+      if (!sample || sample.slope > maxSlope) {
+        continue;
+      }
+
+      const baseHeight = sample.height;
+      const height = THREE.MathUtils.lerp(heightRange[0], heightRange[1], rng());
+      const roofHeight = THREE.MathUtils.lerp(roofHeightRange[0], roofHeightRange[1], rng());
+
+      accumulatedHeight += baseHeight;
+      sampledLots++;
+
+      position.y = baseHeight + height * 0.5;
+      scale.set(footprint, height, depth);
+      applyInstanceTransform(wallMesh, instanceIndex, position, rotationY, scale);
+      wallMesh.setColorAt(instanceIndex, colorFromPalette(rng, wallPalette));
+
+      position.y = baseHeight + height + roofHeight * 0.5 - 0.1;
+      scale.set(footprint * 0.92, roofHeight, depth * 0.92);
+      applyInstanceTransform(roofMesh, instanceIndex, position, rotationY, scale);
+      roofMesh.setColorAt(instanceIndex, colorFromPalette(rng, roofPalette));
+
+      instanceIndex++;
+    }
+  }
+
+  wallMesh.count = instanceIndex;
+  roofMesh.count = instanceIndex;
+  wallMesh.instanceMatrix.needsUpdate = true;
+  roofMesh.instanceMatrix.needsUpdate = true;
+  if (wallMesh.instanceColor) wallMesh.instanceColor.needsUpdate = true;
+  if (roofMesh.instanceColor) roofMesh.instanceColor.needsUpdate = true;
+
+  group.add(wallMesh);
+  group.add(roofMesh);
+
+  const plazaWidth = columns * spacing + 6;
+  const plazaDepth = rows * spacing + 6;
+  const plazaGeometry = new THREE.PlaneGeometry(plazaWidth, plazaDepth, 1, 1);
+  plazaGeometry.rotateX(-Math.PI / 2);
+  const plazaMaterial = new THREE.MeshStandardMaterial({
+    color: 0x8a7f6a,
+    roughness: 0.95,
+    metalness: 0.02,
+  });
+  const plaza = new THREE.Mesh(plazaGeometry, plazaMaterial);
+  const plazaHeight = sampledLots > 0 ? accumulatedHeight / sampledLots : SEA_LEVEL;
+  plaza.position.set(center.x, plazaHeight + 0.02, center.z);
+  plaza.receiveShadow = true;
+  plaza.userData.noCollision = true;
+  group.add(plaza);
+
+  group.userData.city = {
+    walls: wallMesh,
+    roofs: roofMesh,
+    wallMaterial,
+    roofMaterial,
+    plaza,
+    colors: {
+      wallDay: new THREE.Color(0xcbb49a),
+      wallNight: new THREE.Color(0x726c61),
+      roofDay: new THREE.Color(0x7a422a),
+      roofNight: new THREE.Color(0x231410),
+      windowGlow: new THREE.Color(0xffdca8),
+    },
+  };
+
+  return group;
+}
+
+const _lightingColor = new THREE.Color();
+
+export function updateCityLighting(city, nightFactor = 0) {
+  if (!city || !city.userData || !city.userData.city) return;
+  const data = city.userData.city;
+  const t = THREE.MathUtils.clamp(nightFactor, 0, 1);
+
+  _lightingColor.copy(data.colors.wallDay).lerp(data.colors.wallNight, t);
+  data.wallMaterial.color.copy(_lightingColor);
+
+  _lightingColor.copy(data.colors.roofDay).lerp(data.colors.roofNight, t);
+  data.roofMaterial.color.copy(_lightingColor);
+
+  const emissive = THREE.MathUtils.lerp(0.05, 0.35, t);
+  data.wallMaterial.emissive.copy(data.colors.windowGlow).multiplyScalar(emissive * 0.4);
+  data.wallMaterial.emissiveIntensity = emissive;
+  data.roofMaterial.emissiveIntensity = Math.max(0.1 * t, 0.02);
+}

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -1,5 +1,12 @@
 import * as THREE from "three";
 
+export const SEA_LEVEL = -0.8;
+
 export const HARBOR_CENTER = new THREE.Vector2(-120, 80);
-export const HARBOR_CENTER_3D = new THREE.Vector3(-120, 0, 80);
-export const HARBOR_SEA_LEVEL = -0.8;
+export const HARBOR_CENTER_3D = new THREE.Vector3(
+  HARBOR_CENTER.x,
+  SEA_LEVEL,
+  HARBOR_CENTER.y
+);
+export const HARBOR_EXCLUSION_RADIUS = 32;
+export const HARBOR_SEA_LEVEL = SEA_LEVEL;

--- a/src/world/roads.js
+++ b/src/world/roads.js
@@ -1,0 +1,98 @@
+import * as THREE from "three";
+
+const UP = new THREE.Vector3(0, 1, 0);
+const _point = new THREE.Vector3();
+const _tangent = new THREE.Vector3();
+const _binormal = new THREE.Vector3();
+const _side = new THREE.Vector3();
+
+export function createRoad(scene, controlPoints, options = {}) {
+  if (!scene || !controlPoints || controlPoints.length < 2) {
+    return null;
+  }
+
+  const curve = new THREE.CatmullRomCurve3(controlPoints, false, "catmullrom", options.tension ?? 0.5);
+  const segments = Math.max(options.segments ?? controlPoints.length * 16, 8);
+  const width = options.width ?? 2.2;
+  const thickness = options.thickness ?? 0.2;
+
+  const vertexCount = segments * 2;
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  const uvs = new Float32Array(vertexCount * 2);
+  const indices = new Uint32Array((segments - 1) * 6);
+
+  for (let i = 0; i < segments; i++) {
+    const t = i / (segments - 1);
+    curve.getPoint(t, _point);
+    curve.getTangent(t, _tangent).normalize();
+
+    _binormal.crossVectors(UP, _tangent);
+    if (_binormal.lengthSq() < 1e-6) {
+      _binormal.set(1, 0, 0);
+    } else {
+      _binormal.normalize();
+    }
+
+    const halfWidth = width * 0.5;
+    _side.copy(_binormal).multiplyScalar(halfWidth);
+
+    const leftIndex = i * 2;
+    const rightIndex = leftIndex + 1;
+
+    positions[leftIndex * 3 + 0] = _point.x + _side.x;
+    positions[leftIndex * 3 + 1] = _point.y + thickness;
+    positions[leftIndex * 3 + 2] = _point.z + _side.z;
+
+    positions[rightIndex * 3 + 0] = _point.x - _side.x;
+    positions[rightIndex * 3 + 1] = _point.y + thickness;
+    positions[rightIndex * 3 + 2] = _point.z - _side.z;
+
+    normals[leftIndex * 3 + 0] = 0;
+    normals[leftIndex * 3 + 1] = 1;
+    normals[leftIndex * 3 + 2] = 0;
+    normals[rightIndex * 3 + 0] = 0;
+    normals[rightIndex * 3 + 1] = 1;
+    normals[rightIndex * 3 + 2] = 0;
+
+    const v = t * (options.uvScale ?? 4);
+    uvs[leftIndex * 2 + 0] = 0;
+    uvs[leftIndex * 2 + 1] = v;
+    uvs[rightIndex * 2 + 0] = 1;
+    uvs[rightIndex * 2 + 1] = v;
+  }
+
+  for (let i = 0; i < segments - 1; i++) {
+    const i2 = i * 2;
+    const base = i * 6;
+    indices[base + 0] = i2;
+    indices[base + 1] = i2 + 1;
+    indices[base + 2] = i2 + 2;
+    indices[base + 3] = i2 + 1;
+    indices[base + 4] = i2 + 3;
+    indices[base + 5] = i2 + 2;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("normal", new THREE.BufferAttribute(normals, 3));
+  geometry.setAttribute("uv", new THREE.BufferAttribute(uvs, 2));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  geometry.computeVertexNormals();
+
+  const material = new THREE.MeshStandardMaterial({
+    color: options.color ?? 0x4d4335,
+    roughness: 0.95,
+    metalness: 0.05,
+  });
+
+  const road = new THREE.Mesh(geometry, material);
+  road.name = options.name ?? "HarborRoad";
+  road.receiveShadow = true;
+  road.castShadow = false;
+  road.userData.noCollision = options.noCollision ?? false;
+
+  scene.add(road);
+
+  return { mesh: road, curve };
+}


### PR DESCRIPTION
## Summary
- add a deterministic harbor-side city with instanced buildings that react to lighting
- convert harbor posts to a single instanced mesh and add a spline road into the city
- upgrade the ocean to scale with device pixel ratio and support mood-driven visuals

## How to Test
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3bd2ae9a48327b4678e9cb71655d5