### PR TITLE
feat(world): seeded city, harbor instancing, adaptive ocean

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,9 +6,10 @@ import { createLighting, updateLighting, createMoon, updateMoon } from "./world/
 import { createInteractor } from "./world/interactions.js";
 import { attachCrosshair } from "./world/ui/crosshair.js";
 import { createTerrain, updateTerrain } from "./world/terrain.js";
-import { createOcean, updateOcean } from "./world/water.js";
-import { createHarbor } from "./world/harbor.js";
-import { HARBOR_CENTER_3D } from "./world/locations.js";
+import { createOcean, updateOcean } from "./world/ocean.js";
+import { createHarbor, updateHarborLighting } from "./world/harbor.js";
+import { createCity, updateCityLighting } from "./world/city.js";
+import { CITY_CHUNK_CENTER, HARBOR_CENTER_3D } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
 import { InputMap } from "./input/InputMap.js";
@@ -143,7 +144,10 @@ async function mainApp() {
     size: 800,
     position: HARBOR_CENTER_3D.clone(),
   });
-  createHarbor(scene, { center: HARBOR_CENTER_3D });
+  const harbor = createHarbor(scene, { center: HARBOR_CENTER_3D });
+  const city = createCity(scene, terrain, {
+    origin: CITY_CHUNK_CENTER,
+  });
 
   // Lay out a formal civic district with a central promenade, symmetrical
   // civic buildings, and decorative lighting to give the city a planned
@@ -465,6 +469,8 @@ async function mainApp() {
     // Update sky dome, atmospheric lighting, and celestial bodies each frame.
     updateSky(skyObj, sunDir);
     updateLighting(lights, sunDir);
+    updateHarborLighting(harbor, lights.nightFactor);
+    updateCityLighting(city, lights.nightFactor);
     // Fade the stars in and out depending on the time of day.
     updateStars(stars, phase);
     updateMoon(moon, sunDir);
@@ -472,7 +478,7 @@ async function mainApp() {
     // Dynamic terrain subtly sways, hinting at wind. Remove this call if you
     // prefer a static landscape without vertex animation.
     updateTerrain(terrain, elapsed);
-    updateOcean(ocean, deltaTime, sunDir);
+    updateOcean(ocean, deltaTime, sunDir, lights.nightFactor);
 
     // Update player movement and drive the attached character animation.
     player.update(deltaTime);

--- a/src/world/city.js
+++ b/src/world/city.js
@@ -1,0 +1,307 @@
+import * as THREE from "three";
+import {
+  CITY_CHUNK_CENTER,
+  CITY_CHUNK_SIZE,
+  CITY_JITTER,
+  CITY_LAYOUT,
+  CITY_MAX_SLOPE,
+  CITY_COLOR_RANGES,
+  CITY_SEED,
+  CITY_SPACING_X,
+  CITY_SPACING_Z,
+  SEA_LEVEL_Y,
+} from "./locations.js";
+import { createRoad } from "./roads.js";
+
+const _matrix = new THREE.Matrix4();
+const _quaternion = new THREE.Quaternion();
+const _scale = new THREE.Vector3();
+const _roofScale = new THREE.Vector3();
+const _position = new THREE.Vector3();
+const _rotationAxis = new THREE.Vector3(0, 1, 0);
+const _color = new THREE.Color();
+
+function mulberry32(seed) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function sampleHeight(terrain, x, z, fallback) {
+  const getter = terrain?.userData?.getHeightAt;
+  if (typeof getter === "function") {
+    const height = getter(x, z);
+    if (Number.isFinite(height)) {
+      return height;
+    }
+  }
+  return fallback;
+}
+
+function evaluateLot({ terrain, centerX, centerZ, width, depth, rotation, maxSlope }) {
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  const halfWidth = width / 2;
+  const halfDepth = depth / 2;
+
+  const cornerOffsets = [
+    { x: -halfWidth, z: -halfDepth },
+    { x: halfWidth, z: -halfDepth },
+    { x: -halfWidth, z: halfDepth },
+    { x: halfWidth, z: halfDepth },
+  ];
+
+  const heights = [];
+  let minHeight = Infinity;
+  let maxHeight = -Infinity;
+
+  for (const offset of cornerOffsets) {
+    const rotatedX = offset.x * cos - offset.z * sin;
+    const rotatedZ = offset.x * sin + offset.z * cos;
+    const sampleX = centerX + rotatedX;
+    const sampleZ = centerZ + rotatedZ;
+    const h = sampleHeight(terrain, sampleX, sampleZ, null);
+    if (!Number.isFinite(h)) {
+      return null;
+    }
+    heights.push(h);
+    if (h < minHeight) minHeight = h;
+    if (h > maxHeight) maxHeight = h;
+  }
+
+  if (maxHeight - minHeight > maxSlope) {
+    return null;
+  }
+
+  const averageHeight = heights.reduce((sum, value) => sum + value, 0) / heights.length;
+  return {
+    height: averageHeight,
+    minHeight,
+    maxHeight,
+  };
+}
+
+export function createCity(scene, terrain, options = {}) {
+  const origin = options.origin ? options.origin.clone() : CITY_CHUNK_CENTER.clone();
+  const rng = mulberry32(options.seed ?? CITY_SEED);
+  const gridSize = options.gridSize ?? CITY_CHUNK_SIZE.clone();
+  const spacingX = options.spacingX ?? CITY_SPACING_X;
+  const spacingZ = options.spacingZ ?? CITY_SPACING_Z;
+  const jitter = options.jitter ?? CITY_JITTER;
+  const maxSlope = options.maxSlope ?? CITY_MAX_SLOPE;
+  const layoutConfig = CITY_LAYOUT;
+  const buildingConfig = layoutConfig.building;
+  const walkwayConfig = layoutConfig.walkway;
+  const lightingConfig = layoutConfig.lighting;
+  const colorRanges = CITY_COLOR_RANGES;
+
+  const countX = Math.max(3, Math.floor(gridSize.x / spacingX));
+  const countZ = Math.max(3, Math.floor(gridSize.y / spacingZ));
+  const halfX = (countX - 1) * spacingX * 0.5;
+  const halfZ = (countZ - 1) * spacingZ * 0.5;
+
+  const placements = [];
+
+  for (let ix = 0; ix < countX; ix++) {
+    for (let iz = 0; iz < countZ; iz++) {
+      if (rng() < layoutConfig.emptyLotChance) {
+        continue;
+      }
+
+      const centerX = origin.x + (ix * spacingX - halfX) + THREE.MathUtils.lerp(-jitter, jitter, rng());
+      const centerZ = origin.z + (iz * spacingZ - halfZ) + THREE.MathUtils.lerp(-jitter, jitter, rng());
+
+      const width = THREE.MathUtils.lerp(
+        buildingConfig.widthRange[0],
+        buildingConfig.widthRange[1],
+        rng()
+      );
+      const depth = THREE.MathUtils.lerp(
+        buildingConfig.depthRange[0],
+        buildingConfig.depthRange[1],
+        rng()
+      );
+      const wallHeight = THREE.MathUtils.lerp(
+        buildingConfig.wallHeightRange[0],
+        buildingConfig.wallHeightRange[1],
+        rng()
+      );
+      const roofHeight =
+        wallHeight *
+        THREE.MathUtils.lerp(
+          buildingConfig.roofHeightRatioRange[0],
+          buildingConfig.roofHeightRatioRange[1],
+          rng()
+        );
+      const rotationSteps = Math.max(
+        1,
+        options.rotationSteps ?? layoutConfig.rotationSteps
+      );
+      const rotation =
+        Math.floor(rng() * rotationSteps) * ((Math.PI * 2) / rotationSteps);
+
+      const lot = evaluateLot({
+        terrain,
+        centerX,
+        centerZ,
+        width,
+        depth,
+        rotation,
+        maxSlope,
+      });
+
+      if (!lot) {
+        continue;
+      }
+
+      const groundHeight = Math.max(lot.height, SEA_LEVEL_Y + 0.05);
+      placements.push({
+        x: centerX,
+        y: groundHeight,
+        z: centerZ,
+        width,
+        depth,
+        wallHeight,
+        roofHeight,
+        rotation,
+        wallColor: new THREE.Color().setHSL(
+          THREE.MathUtils.lerp(colorRanges.wallHue[0], colorRanges.wallHue[1], rng()),
+          colorRanges.wallSaturation,
+          THREE.MathUtils.lerp(
+            colorRanges.wallLightness[0],
+            colorRanges.wallLightness[1],
+            rng()
+          )
+        ),
+        roofColor: new THREE.Color().setHSL(
+          THREE.MathUtils.lerp(colorRanges.roofHue[0], colorRanges.roofHue[1], rng()),
+          colorRanges.roofSaturation,
+          THREE.MathUtils.lerp(
+            colorRanges.roofLightness[0],
+            colorRanges.roofLightness[1],
+            rng()
+          )
+        ),
+      });
+    }
+  }
+
+  const city = new THREE.Group();
+  city.name = "HarborCity";
+
+  const walkwayPoints = [];
+  const sampleCount = Math.max(2, walkwayConfig.sampleCount);
+  const walkwaySpan = Math.max(gridSize.x, gridSize.y) * walkwayConfig.spanFactor;
+  for (let i = 0; i < sampleCount; i++) {
+    const alpha = sampleCount > 1 ? i / (sampleCount - 1) : 0;
+    const x = origin.x - walkwaySpan * 0.5 + walkwaySpan * alpha;
+    const wave = Math.sin(
+      alpha * Math.PI * walkwayConfig.waveFrequency + walkwayConfig.phaseOffset
+    );
+    const z = origin.z + wave * (gridSize.y * walkwayConfig.amplitudeFactor);
+    const y = sampleHeight(terrain, x, z, SEA_LEVEL_Y) + walkwayConfig.heightOffset;
+    walkwayPoints.push(new THREE.Vector3(x, y, z));
+  }
+  if (walkwayPoints.length >= 2) {
+    createRoad(city, walkwayPoints, {
+      width: walkwayConfig.width,
+      segments: walkwayConfig.segments,
+      name: walkwayConfig.name,
+      noCollision: walkwayConfig.noCollision,
+      color: walkwayConfig.color,
+    });
+  }
+
+  const instanceCount = placements.length;
+  if (instanceCount === 0) {
+    scene.add(city);
+    return city;
+  }
+
+  const wallGeometry = new THREE.BoxGeometry(1, 1, 1);
+  wallGeometry.translate(0, 0.5, 0);
+  const roofGeometry = new THREE.CylinderGeometry(0, 0.5, 1, 4, 1, false);
+  roofGeometry.rotateY(Math.PI / 4);
+  roofGeometry.translate(0, 0.5, 0);
+
+  const wallsMaterial = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    vertexColors: true,
+    roughness: 0.6,
+    metalness: 0.08,
+    emissive: new THREE.Color(0xffdfa1),
+    emissiveIntensity: 0.08,
+  });
+
+  const roofsMaterial = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    vertexColors: true,
+    roughness: 0.85,
+    metalness: 0.05,
+  });
+
+  const walls = new THREE.InstancedMesh(wallGeometry, wallsMaterial, instanceCount);
+  const roofs = new THREE.InstancedMesh(roofGeometry, roofsMaterial, instanceCount);
+  walls.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  roofs.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  walls.castShadow = true;
+  walls.receiveShadow = true;
+  roofs.castShadow = true;
+  roofs.receiveShadow = false;
+
+  for (let i = 0; i < placements.length; i++) {
+    const placement = placements[i];
+    _position.set(placement.x, placement.y, placement.z);
+    _quaternion.setFromAxisAngle(_rotationAxis, placement.rotation);
+    _scale.set(placement.width, placement.wallHeight, placement.depth);
+    _matrix.compose(_position, _quaternion, _scale);
+    walls.setMatrixAt(i, _matrix);
+    walls.setColorAt(i, _color.copy(placement.wallColor));
+
+    _position.y = placement.y + placement.wallHeight;
+    _roofScale.set(
+      placement.width * buildingConfig.roofScale,
+      placement.roofHeight,
+      placement.depth * buildingConfig.roofScale
+    );
+    _matrix.compose(_position, _quaternion, _roofScale);
+    roofs.setMatrixAt(i, _matrix);
+    roofs.setColorAt(i, _color.copy(placement.roofColor));
+  }
+
+  if (walls.instanceMatrix) {
+    walls.instanceMatrix.needsUpdate = true;
+  }
+  if (roofs.instanceMatrix) {
+    roofs.instanceMatrix.needsUpdate = true;
+  }
+  if (walls.instanceColor) walls.instanceColor.needsUpdate = true;
+  if (roofs.instanceColor) roofs.instanceColor.needsUpdate = true;
+
+  city.add(walls);
+  city.add(roofs);
+
+  city.userData.walls = walls;
+  city.userData.roofs = roofs;
+  city.userData.lighting = {
+    material: wallsMaterial,
+    dayIntensity: lightingConfig.dayIntensity,
+    nightIntensity: lightingConfig.nightIntensity,
+  };
+
+  scene.add(city);
+  return city;
+}
+
+export function updateCityLighting(city, nightFactor = 0) {
+  if (!city) return;
+  const lighting = city.userData?.lighting;
+  if (!lighting) return;
+
+  const factor = THREE.MathUtils.clamp(nightFactor, 0, 1);
+  const target = THREE.MathUtils.lerp(lighting.dayIntensity, lighting.nightIntensity, factor);
+  lighting.material.emissiveIntensity = target;
+}

--- a/src/world/harbor.js
+++ b/src/world/harbor.js
@@ -1,16 +1,25 @@
 import * as THREE from "three";
-import { HARBOR_CENTER_3D } from "./locations.js";
+import {
+  HARBOR_APPROACH_LENGTH,
+  HARBOR_CENTER_3D,
+  HARBOR_DECK_HEIGHT,
+  HARBOR_GEOMETRY,
+  HARBOR_MAIN_LENGTH,
+  HARBOR_MAIN_WIDTH,
+  HARBOR_POST_SPACING,
+  HARBOR_POST_RADII,
+  HARBOR_LAMP_CONFIG,
+  HARBOR_SPUR_LENGTH,
+} from "./locations.js";
+
+const _postMatrix = new THREE.Matrix4();
+const _postPosition = new THREE.Vector3();
+const _postScale = new THREE.Vector3(1, 1, 1);
+const _identityQuaternion = new THREE.Quaternion();
 
 function enableShadows(mesh) {
   mesh.castShadow = true;
   mesh.receiveShadow = true;
-}
-
-function createSupportPost(material, height, radiusTop, radiusBottom) {
-  const geometry = new THREE.CylinderGeometry(radiusTop, radiusBottom, height, 12);
-  const post = new THREE.Mesh(geometry, material);
-  enableShadows(post);
-  return post;
 }
 
 function createWoodMaterial(color) {
@@ -21,7 +30,7 @@ function createWoodMaterial(color) {
   });
 }
 
-function populatePosts(group, options) {
+function accumulateEdgePosts(target, options) {
   const {
     width,
     length,
@@ -29,39 +38,56 @@ function populatePosts(group, options) {
     offsetX = 0,
     offsetZ = 0,
     deckHeight,
-    postMaterial,
+    postHeight,
+    inset = HARBOR_GEOMETRY.postInset,
   } = options;
 
-  const postHeight = deckHeight + 3;
-  const halfWidth = width / 2 - 0.6;
-  const halfLength = length / 2 - 0.6;
+  const halfWidth = width / 2 - inset;
+  const halfLength = length / 2 - inset;
+  const baseY = deckHeight - postHeight;
 
-  for (let z = -halfLength; z <= halfLength; z += spacing) {
-    const leftPost = createSupportPost(postMaterial, postHeight, 0.45, 0.55);
-    leftPost.position.set(offsetX - halfWidth, deckHeight - postHeight / 2, offsetZ + z);
-    group.add(leftPost);
-
-    const rightPost = createSupportPost(postMaterial, postHeight, 0.45, 0.55);
-    rightPost.position.set(offsetX + halfWidth, deckHeight - postHeight / 2, offsetZ + z);
-    group.add(rightPost);
+  for (let z = -halfLength; z <= halfLength + 1e-3; z += spacing) {
+    target.push({ x: offsetX - halfWidth, y: baseY, z: offsetZ + z });
+    target.push({ x: offsetX + halfWidth, y: baseY, z: offsetZ + z });
   }
 }
 
-function createCrate(size, material) {
-  const geometry = new THREE.BoxGeometry(size, size, size);
-  const crate = new THREE.Mesh(geometry, material);
-  enableShadows(crate);
-  return crate;
+function buildPostMesh(name, positions, { height, radiusTop, radiusBottom, material }) {
+  if (!positions || positions.length === 0) {
+    return null;
+  }
+
+  const geometry = new THREE.CylinderGeometry(radiusTop, radiusBottom, height, 12);
+  geometry.translate(0, height / 2, 0);
+
+  const mesh = new THREE.InstancedMesh(geometry, material, positions.length);
+  mesh.name = name;
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+
+  for (let i = 0; i < positions.length; i++) {
+    const position = positions[i];
+    _postPosition.set(position.x, position.y, position.z);
+    _postMatrix.compose(_postPosition, _identityQuaternion, _postScale);
+    mesh.setMatrixAt(i, _postMatrix);
+  }
+
+  mesh.instanceMatrix.needsUpdate = true;
+  return mesh;
 }
 
 export function createHarbor(scene, options = {}) {
   const center = options.center ? options.center.clone() : HARBOR_CENTER_3D.clone();
-  const mainLength = options.mainLength ?? 70;
-  const mainWidth = options.mainWidth ?? 9;
-  const deckHeight = options.deckHeight ?? 1.4;
-  const approachLength = options.approachLength ?? 32;
-  const spurLength = options.spurLength ?? 24;
-  const postSpacing = options.postSpacing ?? 6;
+  const mainLength = options.mainLength ?? HARBOR_MAIN_LENGTH;
+  const mainWidth = options.mainWidth ?? HARBOR_MAIN_WIDTH;
+  const deckHeight = options.deckHeight ?? HARBOR_DECK_HEIGHT;
+  const approachLength = options.approachLength ?? HARBOR_APPROACH_LENGTH;
+  const spurLength = options.spurLength ?? HARBOR_SPUR_LENGTH;
+  const postSpacing = options.postSpacing ?? HARBOR_POST_SPACING;
+  const geometryConfig = HARBOR_GEOMETRY;
+  const postHeightOffset = geometryConfig.postHeightBelowDeck;
+  const approachWidth = mainWidth - geometryConfig.approachWidthReduction;
+  const lampConfig = HARBOR_LAMP_CONFIG;
 
   const deckMaterial = createWoodMaterial(0x7b5b3f);
   const postMaterial = createWoodMaterial(0x4a3a27);
@@ -75,79 +101,119 @@ export function createHarbor(scene, options = {}) {
   harbor.name = "Harbor";
   harbor.position.copy(center);
 
-  const mainDeck = new THREE.Mesh(new THREE.BoxGeometry(mainWidth, 0.6, mainLength), deckMaterial);
+  const mainDeck = new THREE.Mesh(
+    new THREE.BoxGeometry(mainWidth, geometryConfig.deckThickness, mainLength),
+    deckMaterial
+  );
   mainDeck.position.y = deckHeight;
   enableShadows(mainDeck);
   harbor.add(mainDeck);
 
-  populatePosts(harbor, {
+  const pierPostPositions = [];
+  const pierPostHeight = deckHeight + postHeightOffset;
+  accumulateEdgePosts(pierPostPositions, {
     width: mainWidth,
     length: mainLength,
     spacing: postSpacing,
     deckHeight,
-    postMaterial,
+    postHeight: pierPostHeight,
+  });
+  accumulateEdgePosts(pierPostPositions, {
+    width: mainWidth - geometryConfig.spurWidthReduction,
+    length: spurLength,
+    spacing: postSpacing,
+    deckHeight,
+    postHeight: pierPostHeight,
+    offsetX: -mainWidth / 2 + geometryConfig.spurOffsetX,
+    offsetZ: spurLength / 2 + geometryConfig.spurOffsetZ,
+  });
+  accumulateEdgePosts(pierPostPositions, {
+    width: mainWidth - geometryConfig.spurWidthReduction,
+    length: spurLength,
+    spacing: postSpacing,
+    deckHeight,
+    postHeight: pierPostHeight,
+    offsetX: -mainWidth / 2 + geometryConfig.spurOffsetX,
+    offsetZ: -(spurLength / 2 + geometryConfig.spurOffsetZ),
   });
 
+  const pierPosts = buildPostMesh("HarborPierPosts", pierPostPositions, {
+    height: pierPostHeight,
+    radiusTop: HARBOR_POST_RADII.pier.top,
+    radiusBottom: HARBOR_POST_RADII.pier.bottom,
+    material: postMaterial,
+  });
+  if (pierPosts) {
+    harbor.add(pierPosts);
+  }
+
   const approach = new THREE.Mesh(
-    new THREE.BoxGeometry(approachLength, 0.5, mainWidth - 2),
+    new THREE.BoxGeometry(
+      approachLength,
+      geometryConfig.approachDeckThickness,
+      approachWidth
+    ),
     deckMaterial
   );
   approach.position.set(mainWidth / 2 + approachLength / 2, deckHeight, 0);
   enableShadows(approach);
   harbor.add(approach);
 
-  const walkwaySupports = new THREE.Group();
-  const walkwayHalfWidth = (mainWidth - 2) / 2 - 0.6;
-  const walkwayPostHeight = deckHeight + 3;
-  for (let x = -approachLength / 2; x <= approachLength / 2; x += postSpacing) {
-    const left = createSupportPost(postMaterial, walkwayPostHeight, 0.4, 0.5);
-    left.position.set(x, deckHeight - walkwayPostHeight / 2, -walkwayHalfWidth);
-    walkwaySupports.add(left);
-
-    const right = createSupportPost(postMaterial, walkwayPostHeight, 0.4, 0.5);
-    right.position.set(x, deckHeight - walkwayPostHeight / 2, walkwayHalfWidth);
-    walkwaySupports.add(right);
+  const walkwayPostHeight = deckHeight + postHeightOffset;
+  const walkwayHalfWidth = approachWidth / 2 - geometryConfig.postInset;
+  const walkwayPosts = [];
+  const walkwayBaseX = mainWidth / 2 + approachLength / 2;
+  const walkwayBaseY = deckHeight - walkwayPostHeight;
+  for (let x = -approachLength / 2; x <= approachLength / 2 + 1e-3; x += postSpacing) {
+    walkwayPosts.push({ x: walkwayBaseX + x, y: walkwayBaseY, z: -walkwayHalfWidth });
+    walkwayPosts.push({ x: walkwayBaseX + x, y: walkwayBaseY, z: walkwayHalfWidth });
   }
-  walkwaySupports.position.x = mainWidth / 2 + approachLength / 2;
-  harbor.add(walkwaySupports);
+  const walkwayPostMesh = buildPostMesh("HarborWalkwayPosts", walkwayPosts, {
+    height: walkwayPostHeight,
+    radiusTop: HARBOR_POST_RADII.walkway.top,
+    radiusBottom: HARBOR_POST_RADII.walkway.bottom,
+    material: postMaterial,
+  });
+  if (walkwayPostMesh) {
+    harbor.add(walkwayPostMesh);
+  }
 
-  const northSpur = new THREE.Mesh(new THREE.BoxGeometry(mainWidth - 4, 0.45, spurLength), deckMaterial);
-  northSpur.position.set(-mainWidth / 2 + 1.2, deckHeight, spurLength / 2 + 2);
+  const northSpur = new THREE.Mesh(
+    new THREE.BoxGeometry(
+      mainWidth - geometryConfig.spurWidthReduction,
+      geometryConfig.spurDeckThickness,
+      spurLength
+    ),
+    deckMaterial
+  );
+  northSpur.position.set(
+    -mainWidth / 2 + geometryConfig.spurOffsetX,
+    deckHeight,
+    spurLength / 2 + geometryConfig.spurOffsetZ
+  );
   enableShadows(northSpur);
   harbor.add(northSpur);
 
-  populatePosts(harbor, {
-    width: mainWidth - 4,
-    length: spurLength,
-    spacing: postSpacing,
-    offsetX: -mainWidth / 2 + 1.2,
-    offsetZ: spurLength / 2 + 2,
-    deckHeight,
-    postMaterial,
-  });
-
   const southSpur = northSpur.clone();
-  southSpur.position.z = -(spurLength / 2 + 2);
+  southSpur.position.z = -(spurLength / 2 + geometryConfig.spurOffsetZ);
   harbor.add(southSpur);
 
-  populatePosts(harbor, {
-    width: mainWidth - 4,
-    length: spurLength,
-    spacing: postSpacing,
-    offsetX: -mainWidth / 2 + 1.2,
-    offsetZ: -(spurLength / 2 + 2),
-    deckHeight,
-    postMaterial,
-  });
-
-  const railingGeometry = new THREE.BoxGeometry(0.2, 1.1, mainLength);
+  const railingGeometry = new THREE.BoxGeometry(
+    geometryConfig.railingThickness,
+    geometryConfig.railingHeight,
+    mainLength
+  );
   const railLeft = new THREE.Mesh(railingGeometry, trimMaterial);
-  railLeft.position.set(-mainWidth / 2 + 0.6, deckHeight + 0.8, 0);
+  railLeft.position.set(
+    -mainWidth / 2 + geometryConfig.railingOffsetX,
+    deckHeight + geometryConfig.railingYOffset,
+    0
+  );
   enableShadows(railLeft);
   harbor.add(railLeft);
 
   const railRight = railLeft.clone();
-  railRight.position.x = mainWidth / 2 - 0.6;
+  railRight.position.x = mainWidth / 2 - geometryConfig.railingOffsetX;
   harbor.add(railRight);
 
   const bollardGeometry = new THREE.CylinderGeometry(0.35, 0.35, 0.8, 16);
@@ -172,61 +238,129 @@ export function createHarbor(scene, options = {}) {
   }
 
   const crateMaterial = createWoodMaterial(0x8f6b45);
-  const crateA = createCrate(2.4, crateMaterial);
+  const crateA = new THREE.Mesh(new THREE.BoxGeometry(2.4, 2.4, 2.4), crateMaterial);
   crateA.position.set(mainWidth / 2 - 2, deckHeight + 1.2, -mainLength / 4);
+  enableShadows(crateA);
   harbor.add(crateA);
 
-  const crateB = createCrate(1.6, crateMaterial);
+  const crateB = new THREE.Mesh(new THREE.BoxGeometry(1.6, 1.6, 1.6), crateMaterial);
   crateB.position.set(mainWidth / 2 - 3.4, deckHeight + 0.8, -mainLength / 4 + 3);
+  enableShadows(crateB);
   harbor.add(crateB);
 
-  const crateC = createCrate(1.8, crateMaterial);
+  const crateC = new THREE.Mesh(new THREE.BoxGeometry(1.8, 1.8, 1.8), crateMaterial);
   crateC.position.set(mainWidth / 2 - 2.4, deckHeight + 0.9, -mainLength / 4 - 2.4);
+  enableShadows(crateC);
   harbor.add(crateC);
 
   const lamp = new THREE.Group();
   lamp.name = "HarborLamp";
-  lamp.position.set(mainWidth / 2 + approachLength - 4, 0, 0);
+  lamp.position.set(
+    mainWidth / 2 + approachLength - geometryConfig.walkwayLampOffset,
+    0,
+    0
+  );
 
-  const lampPole = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 4, 16), trimMaterial);
-  lampPole.position.y = 2;
+  const lampPole = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      lampConfig.pole.radiusTop,
+      lampConfig.pole.radiusBottom,
+      lampConfig.pole.height,
+      16
+    ),
+    trimMaterial
+  );
+  lampPole.position.y = lampConfig.pole.height / 2;
   lampPole.castShadow = true;
   lampPole.receiveShadow = false;
   lamp.add(lampPole);
 
-  const lampArm = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.2, 1.6), trimMaterial);
-  lampArm.position.set(0, 3.4, 0.6);
+  const lampArm = new THREE.Mesh(
+    new THREE.BoxGeometry(
+      lampConfig.arm.size.x,
+      lampConfig.arm.size.y,
+      lampConfig.arm.size.z
+    ),
+    trimMaterial
+  );
+  lampArm.position.set(0, lampConfig.arm.height, lampConfig.arm.forwardOffset);
   enableShadows(lampArm);
   lamp.add(lampArm);
 
   const lampBulbMaterial = new THREE.MeshStandardMaterial({
     color: 0xffffff,
-    emissive: new THREE.Color(0xfff2c8),
-    emissiveIntensity: 1.6,
+    emissive: new THREE.Color(lampConfig.bulb.emissiveColor),
+    emissiveIntensity: 0,
   });
-  const lampBulb = new THREE.Mesh(new THREE.SphereGeometry(0.28, 16, 16), lampBulbMaterial);
-  lampBulb.position.set(0, 3.2, 1.2);
+  const lampBulb = new THREE.Mesh(
+    new THREE.SphereGeometry(lampConfig.bulb.radius, 16, 16),
+    lampBulbMaterial
+  );
+  lampBulb.position.set(0, lampConfig.bulb.height, lampConfig.bulb.forwardOffset);
   lampBulb.castShadow = false;
   lamp.add(lampBulb);
 
-  const lampLight = new THREE.PointLight(0xfff2c8, 1.4, 18, 2);
+  const lampLight = new THREE.PointLight(
+    lampConfig.light.color,
+    0,
+    lampConfig.light.range,
+    lampConfig.light.decay
+  );
   lampLight.position.copy(lampBulb.position);
   lampLight.castShadow = true;
   lamp.add(lampLight);
 
+  const lampState = {
+    light: lampLight,
+    material: lampBulbMaterial,
+    baseIntensity: lampConfig.baseIntensity,
+    overrideState: null,
+  };
+
   lamp.userData.interactable = true;
   lamp.userData.highlightTarget = lampBulb;
   lamp.userData.light = lampLight;
-  lamp.userData.onUse = (object) => {
-    const light = object.userData.light;
-    if (!light) return;
-    const active = light.intensity > 0.1;
-    light.intensity = active ? 0 : 1.4;
-    lampBulbMaterial.emissiveIntensity = active ? 0 : 1.6;
+  lamp.userData.onUse = () => {
+    const state = lampState.overrideState;
+    if (state === null) {
+      lampState.overrideState = true;
+    } else if (state === true) {
+      lampState.overrideState = false;
+    } else {
+      lampState.overrideState = null;
+    }
   };
+
+  harbor.userData.lamp = lampState;
 
   harbor.add(lamp);
 
+  harbor.userData.posts = {
+    pier: pierPosts,
+    walkway: walkwayPostMesh,
+  };
+
   scene.add(harbor);
   return harbor;
+}
+
+export function updateHarborLighting(harbor, nightFactor = 0) {
+  if (!harbor) return;
+  const lampState = harbor.userData?.lamp;
+  if (!lampState) return;
+
+  const clamped = THREE.MathUtils.clamp(nightFactor, 0, 1);
+  let intensity = THREE.MathUtils.lerp(0, lampState.baseIntensity, clamped);
+  if (lampState.overrideState === true) {
+    intensity = lampState.baseIntensity;
+  } else if (lampState.overrideState === false) {
+    intensity = 0;
+  }
+
+  lampState.light.intensity = intensity;
+
+  if (lampState.material) {
+    const normalized = lampState.baseIntensity > 0 ? intensity / lampState.baseIntensity : 0;
+    lampState.material.emissiveIntensity = normalized > 0 ? 1.6 * normalized : 0;
+  }
 }

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -1,5 +1,99 @@
 import * as THREE from "three";
 
+export const SEA_LEVEL_Y = -0.8;
+
 export const HARBOR_CENTER = new THREE.Vector2(-120, 80);
-export const HARBOR_CENTER_3D = new THREE.Vector3(-120, 0, 80);
-export const HARBOR_SEA_LEVEL = -0.8;
+export const HARBOR_CENTER_3D = new THREE.Vector3(
+  HARBOR_CENTER.x,
+  SEA_LEVEL_Y,
+  HARBOR_CENTER.y
+);
+export const HARBOR_SEA_LEVEL = SEA_LEVEL_Y;
+export const HARBOR_MAIN_LENGTH = 70;
+export const HARBOR_MAIN_WIDTH = 9;
+export const HARBOR_APPROACH_LENGTH = 32;
+export const HARBOR_SPUR_LENGTH = 24;
+export const HARBOR_POST_SPACING = 6;
+export const HARBOR_DECK_HEIGHT = 1.4;
+
+export const HARBOR_GEOMETRY = Object.freeze({
+  deckThickness: 0.6,
+  approachDeckThickness: 0.5,
+  spurDeckThickness: 0.45,
+  approachWidthReduction: 2,
+  spurWidthReduction: 4,
+  spurOffsetX: 1.2,
+  spurOffsetZ: 2,
+  railingThickness: 0.2,
+  railingHeight: 1.1,
+  railingYOffset: 0.8,
+  railingOffsetX: 0.6,
+  postInset: 0.6,
+  postHeightBelowDeck: 3,
+  walkwayLampOffset: 4,
+});
+
+export const HARBOR_POST_RADII = Object.freeze({
+  pier: Object.freeze({ top: 0.45, bottom: 0.55 }),
+  walkway: Object.freeze({ top: 0.4, bottom: 0.5 }),
+});
+
+export const HARBOR_LAMP_CONFIG = Object.freeze({
+  pole: Object.freeze({ radiusTop: 0.12, radiusBottom: 0.16, height: 4 }),
+  arm: Object.freeze({
+    size: Object.freeze({ x: 0.2, y: 0.2, z: 1.6 }),
+    height: 3.4,
+    forwardOffset: 0.6,
+  }),
+  bulb: Object.freeze({
+    radius: 0.28,
+    height: 3.2,
+    forwardOffset: 1.2,
+    emissiveColor: 0xfff2c8,
+  }),
+  light: Object.freeze({ color: 0xfff2c8, range: 18, decay: 2 }),
+  baseIntensity: 1.4,
+});
+
+export const CITY_CHUNK_CENTER = new THREE.Vector3(-70, 0, 25);
+export const CITY_CHUNK_SIZE = new THREE.Vector2(72, 54);
+export const CITY_SEED = 0x4d534349;
+export const CITY_SPACING_X = 11;
+export const CITY_SPACING_Z = 10;
+export const CITY_JITTER = 2.2;
+export const CITY_MAX_SLOPE = 1.4;
+
+export const CITY_LAYOUT = Object.freeze({
+  emptyLotChance: 0.18,
+  rotationSteps: 4,
+  walkway: Object.freeze({
+    sampleCount: 5,
+    spanFactor: 0.6,
+    amplitudeFactor: 0.45,
+    waveFrequency: 1.2,
+    phaseOffset: -Math.PI * 0.3,
+    heightOffset: 0.02,
+    width: 3.2,
+    segments: 64,
+    color: 0x4b3f35,
+    name: "CityWalkway",
+    noCollision: true,
+  }),
+  building: Object.freeze({
+    widthRange: Object.freeze([4.4, 7.2]),
+    depthRange: Object.freeze([4.2, 7.8]),
+    wallHeightRange: Object.freeze([2.6, 3.8]),
+    roofHeightRatioRange: Object.freeze([0.38, 0.55]),
+    roofScale: 1.04,
+  }),
+  lighting: Object.freeze({ dayIntensity: 0.08, nightIntensity: 1.35 }),
+});
+
+export const CITY_COLOR_RANGES = Object.freeze({
+  wallHue: Object.freeze([0.08, 0.13]),
+  wallSaturation: 0.45,
+  wallLightness: Object.freeze([0.62, 0.74]),
+  roofHue: Object.freeze([0.02, 0.04]),
+  roofSaturation: 0.55,
+  roofLightness: Object.freeze([0.23, 0.32]),
+});

--- a/src/world/roads.js
+++ b/src/world/roads.js
@@ -1,0 +1,102 @@
+import * as THREE from "three";
+
+const _point = new THREE.Vector3();
+const _tangent = new THREE.Vector3();
+const _side = new THREE.Vector3();
+const _left = new THREE.Vector3();
+const _right = new THREE.Vector3();
+const _up = new THREE.Vector3(0, 1, 0);
+
+function createIndices(segmentCount, vertexStride) {
+  const indexCount = segmentCount * 6;
+  const IndexArray = vertexStride * (segmentCount + 1) > 65535 ? Uint32Array : Uint16Array;
+  return new IndexArray(indexCount);
+}
+
+export function createRoad(parent, points, options = {}) {
+  const controlPoints = points ?? options.points;
+  if (!controlPoints || controlPoints.length < 2) {
+    throw new Error("createRoad requires at least two control points");
+  }
+
+  const width = options.width ?? 4;
+  const tension = options.tension ?? 0.5;
+  const closed = Boolean(options.closed);
+  const halfWidth = width / 2;
+
+  const curve = new THREE.CatmullRomCurve3(controlPoints, closed, "centripetal", tension);
+  const segmentCount = options.segments ?? Math.max(16, controlPoints.length * 8);
+
+  const vertexCount = (segmentCount + 1) * 2;
+  const positions = new Float32Array(vertexCount * 3);
+  const uvs = new Float32Array(vertexCount * 2);
+  const indices = createIndices(segmentCount, 2);
+
+  let posOffset = 0;
+  let uvOffset = 0;
+
+  for (let i = 0; i <= segmentCount; i++) {
+    const t = i / segmentCount;
+    curve.getPointAt(t, _point);
+    curve.getTangentAt(t, _tangent).normalize();
+
+    _side.crossVectors(_up, _tangent);
+    if (_side.lengthSq() < 1e-6) {
+      _side.set(1, 0, 0);
+    } else {
+      _side.normalize();
+    }
+
+    _left.copy(_point).addScaledVector(_side, halfWidth);
+    _right.copy(_point).addScaledVector(_side, -halfWidth);
+
+    positions[posOffset++] = _left.x;
+    positions[posOffset++] = _left.y;
+    positions[posOffset++] = _left.z;
+    positions[posOffset++] = _right.x;
+    positions[posOffset++] = _right.y;
+    positions[posOffset++] = _right.z;
+
+    const v = t * (options.uvScale ?? 1);
+    uvs[uvOffset++] = 0;
+    uvs[uvOffset++] = v;
+    uvs[uvOffset++] = 1;
+    uvs[uvOffset++] = v;
+  }
+
+  let indexOffset = 0;
+  for (let i = 0; i < segmentCount; i++) {
+    const base = i * 2;
+    indices[indexOffset++] = base;
+    indices[indexOffset++] = base + 1;
+    indices[indexOffset++] = base + 2;
+    indices[indexOffset++] = base + 1;
+    indices[indexOffset++] = base + 3;
+    indices[indexOffset++] = base + 2;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute("uv", new THREE.BufferAttribute(uvs, 2));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+  geometry.computeVertexNormals();
+
+  const material = new THREE.MeshStandardMaterial({
+    color: options.color ?? 0x393024,
+    roughness: 0.95,
+    metalness: 0.05,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = options.name ?? "CityRoad";
+  mesh.receiveShadow = true;
+  mesh.castShadow = false;
+  mesh.userData.noCollision = options.noCollision ?? true;
+
+  if (parent) {
+    parent.add(mesh);
+  }
+
+  return mesh;
+}


### PR DESCRIPTION
## Summary
- add a seeded harbor city chunk that snaps instanced homes to the terrain and lays out a spline road
- convert harbor posts to instanced meshes, store shared location constants, and drive harbor lighting from day/night
- scale ocean quality with device pixel ratio, calm waves at night, and teach the collider to include instanced meshes
- centralize harbor geometry and city layout configuration in locations.js and reuse them throughout the generators

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e3bb0c90e083278871cffb28a5f00e