### PR TITLE
feat: auto-detect KTX2 transcoder path

### DIFF
--- a/src/world/landmarks.js
+++ b/src/world/landmarks.js
@@ -4,6 +4,9 @@ import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { KTX2Loader } from "three/examples/jsm/loaders/KTX2Loader.js";
 import { MeshoptDecoder } from "three/examples/jsm/libs/meshopt_decoder.module.js";
 
+const DEFAULT_BASIS_TRANSCODER_PATH =
+  "https://unpkg.com/three@0.160.0/examples/jsm/libs/basis/";
+
 // Reuse a single loader instance so we don't repeatedly allocate it whenever we
 // load a new landmark. GLTFLoader understands the .glb format which packages a
 // model and all of its textures into one binary file.
@@ -37,7 +40,26 @@ export function initializeAssetTranscoders(renderer) {
   }
 
   if (!ktx2Loader) {
-    ktx2Loader = new KTX2Loader().setTranscoderPath("/basis/");
+    let transcoderPath = null;
+
+    if (
+      typeof import.meta !== "undefined" &&
+      import.meta &&
+      import.meta.env &&
+      import.meta.env.VITE_BASIS_TRANSCODER_PATH
+    ) {
+      transcoderPath = import.meta.env.VITE_BASIS_TRANSCODER_PATH;
+    } else if (
+      typeof window !== "undefined" &&
+      window &&
+      window.__BASIS_TRANSCODER_PATH__
+    ) {
+      transcoderPath = window.__BASIS_TRANSCODER_PATH__;
+    } else {
+      transcoderPath = DEFAULT_BASIS_TRANSCODER_PATH;
+    }
+
+    ktx2Loader = new KTX2Loader().setTranscoderPath(transcoderPath);
   }
 
   try {


### PR DESCRIPTION
## Summary
- add a default constant for the basis transcoder assets hosted on the three.js CDN
- update the KTX2 loader setup to prefer VITE_BASIS_TRANSCODER_PATH, then window.__BASIS_TRANSCODER_PATH__, and finally fall back to the CDN path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e4449a0ef883279fe3580cefcaebd9