### PR TITLE
Refresh env collider after civic district

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,16 @@ async function mainApp() {
     greensWidth: 9,
   });
 
+  const input = new InputMap(renderer.domElement);
+  const envCollider = new EnvironmentCollider();
+  scene.add(envCollider.mesh);
+  const player = new PlayerController(input, envCollider, { camera });
+  scene.add(player.object);
+
+  // Refresh the environment collider after major static additions like the
+  // civic district so promenade geometry participates in collision checks.
+  envCollider.fromStaticScene(scene);
+
   // Example interactable props. userData acts like a metadata bag so you can
   // describe behaviour without subclassing three.js meshes. Below we hook up a
   // swinging door and a street lamp that toggles its light.
@@ -226,11 +236,6 @@ async function mainApp() {
 
   scene.add(lamp);
 
-  const input = new InputMap(renderer.domElement);
-  const envCollider = new EnvironmentCollider();
-  scene.add(envCollider.mesh);
-  const player = new PlayerController(input, envCollider, { camera });
-  scene.add(player.object);
   envCollider.fromStaticScene(scene);
 
   const createFallbackAvatar = () => {


### PR DESCRIPTION
## Summary
- create the environment collider immediately after the civic district is added
- refresh static collision data after setting up the civic district and again after interactable props

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e445c6f4c88327af40d86b95b5770d