### PR TITLE
Clarify water anisotropy rationale

### DIFF
--- a/src/world/ocean.js
+++ b/src/world/ocean.js
@@ -34,6 +34,7 @@ function createProceduralWaterNormals(size = 256) {
   const texture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Maintain conservative anisotropy to avoid potential mobile performance regressions.
   texture.anisotropy = 4;
   texture.needsUpdate = true;
   return texture;


### PR DESCRIPTION
## Summary
- document why ocean normal map anisotropy remains conservative for mobile performance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4476e99808327ab76886d1bd66aa9