### PR TITLE
Improve asset probe logging for hero and tomb models

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -287,11 +287,7 @@ async function mainApp() {
   if (heroAssetUrl) {
     if (heroAssetUrl !== heroPath) {
       console.info(
-        [
-          `Hero avatar not detected at "${heroPath}".`,
-          "Using the bundled \"Hooded Adventurer\" sample avatar instead.",
-          "Drop your own GLB at public/models/character/hero.glb to override it.",
-        ].join(" ")
+        `Hero GLB not found at ${heroPath}; using bundled sample avatar.`
       );
     }
     try {
@@ -305,9 +301,8 @@ async function mainApp() {
       attachFallbackAvatar();
     }
   } else {
-    console.info(
-      `Hero avatar not detected at "${heroPath}". Drop a model in public/models/character/hero.glb to enable the full character. mainApp will continue with a placeholder avatar.`
-    );
+    console.info(`Hero GLB not found at ${heroPath}; using placeholder avatar.`);
+    console.info(`Add your own hero model at ${heroPath}.`);
     attachFallbackAvatar();
   }
 
@@ -398,10 +393,9 @@ async function mainApp() {
   };
   const buildingBase = `${BASE_URL}models/buildings/`;
 
-  const tombUrlCandidates = [
-    `${buildingBase}aristotle-tomb.glb`,
-    `${BASE_URL}athens-game-starter/models/buildings/aristotle-tomb.gltf`,
-  ];
+  const tombPrimaryPath = `${buildingBase}aristotle-tomb.glb`;
+  const tombBundledPath = `${buildingBase}aristotle-tomb.gltf`;
+  const tombUrlCandidates = [tombPrimaryPath, tombBundledPath];
   const tombUrl = await resolveFirstAvailableAsset(tombUrlCandidates);
   const fallbackUrl = `${buildingBase}Akropol.glb`;
   const fallbackAvailable = await probeAsset(fallbackUrl);
@@ -415,10 +409,7 @@ async function mainApp() {
       }
     } else {
       console.info(
-        [
-          "Akropol fallback model not bundled to keep the repository lightweight.",
-          "Run npm run download:aristotle or place your own GLB in public/models/buildings/.",
-        ].join(" ")
+        `Akropol fallback not bundled; add ${fallbackUrl} or run npm run download:aristotle.`
       );
     }
 
@@ -428,11 +419,9 @@ async function mainApp() {
   if (tombUrl) {
     if (tombUrl !== tombUrlCandidates[0]) {
       console.info(
-        [
-          "Aristotle's Tomb premium asset not downloaded yet.",
-          "Rendering the bundled placeholder version until you run npm run download:aristotle.",
-        ].join(" ")
+        `Aristotle's Tomb missing at ${tombPrimaryPath}; using bundled placeholder.`
       );
+      console.info("Run npm run download:aristotle to install the premium asset.");
     }
     try {
       await buildingMgr.loadBuilding(tombUrl, tombOptions);
@@ -445,7 +434,7 @@ async function mainApp() {
     }
   } else {
     console.info(
-      "Aristotle's Tomb premium asset not detected. Install it with npm run download:aristotle."
+      `Aristotle's Tomb missing at ${tombPrimaryPath}; install it with npm run download:aristotle.`
     );
     await loadFallbackMonument();
   }


### PR DESCRIPTION
## Summary
- streamline hero asset fallback logging and reference the resolved BASE_URL path
- normalize Aristotle's Tomb asset candidates and tips to use BASE_URL-aware paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e44a4497948327876d1c5ac6304f69