### PR TITLE
Enable renderer shadow maps

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -104,6 +104,8 @@ function startTimeOfDayCycle(options = {}) {
 async function mainApp() {
   console.log("🔧 Athens mainApp start");
   const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap; // softer, stable penumbras
   configureRendererShadows(renderer);
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);


### PR DESCRIPTION
## Summary
- enable WebGL renderer shadow maps for softer, stable penumbras

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e451c44a1483278ab4e51f712ad476