### PR TITLE
Improve sun shadows and renderer color space

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -104,6 +104,9 @@ function startTimeOfDayCycle(options = {}) {
 async function mainApp() {
   console.log("🔧 Athens mainApp start");
   const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap; // softer, stable penumbras
+  renderer.outputColorSpace = THREE.SRGBColorSpace; // modern three.js
   configureRendererShadows(renderer);
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);

--- a/src/world/lighting.js
+++ b/src/world/lighting.js
@@ -34,14 +34,13 @@ export function createLighting(scene) {
   // Create the primary sunlight directional light.
   const sunLight = new DirectionalLight(0xffffff, 1.0);
   sunLight.castShadow = true;
-  sunLight.shadow.mapSize.set(2048, 2048);
-  sunLight.shadow.camera.near = 1;
-  sunLight.shadow.camera.far = 600;
-  sunLight.shadow.camera.left = -200;
-  sunLight.shadow.camera.right = 200;
-  sunLight.shadow.camera.top = 200;
-  sunLight.shadow.camera.bottom = -200;
-  sunLight.shadow.bias = -0.001;
+  sunLight.shadow.mapSize.set(1024, 1024);
+  sunLight.shadow.bias = -0.0005;
+  const cam = sunLight.shadow.camera;
+  cam.near = 1;
+  cam.far = 300;
+  cam.left = -120; cam.right = 120;
+  cam.top  = 120;  cam.bottom = -120;
   sunLight.shadow.normalBias = 0.02;
   sunLight.shadow.camera.updateProjectionMatrix();
   scene.add(sunLight);


### PR DESCRIPTION
## Summary
- lower the sun shadow map size to 1024 for balanced performance
- adjust directional light shadow bias and camera bounds to reduce acne and peter-panning
- set the WebGL renderer output color space to sRGB for accurate color rendering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e451c44a1483278ab4e51f712ad476