### PR TITLE
Set renderer output color space to sRGB

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,7 @@ async function mainApp() {
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap; // softer, stable penumbras
   configureRendererShadows(renderer);
+  renderer.outputColorSpace = THREE.SRGBColorSpace; // modern three.js
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
   initializeAssetTranscoders(renderer);


### PR DESCRIPTION
## Summary
- configure the WebGL renderer to output in the modern sRGB color space for correct color rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4563b580c832783638d265f470b60