### PR TITLE
chore(color): set SRGB output and ACES tone mapping

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -104,10 +104,12 @@ function startTimeOfDayCycle(options = {}) {
 async function mainApp() {
   console.log("🔧 Athens mainApp start");
   const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.0;
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap; // softer, stable penumbras
   configureRendererShadows(renderer);
-  renderer.outputColorSpace = THREE.SRGBColorSpace; // modern three.js
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
   initializeAssetTranscoders(renderer);


### PR DESCRIPTION
## Summary
- set the renderer output to the sRGB color space for improved color fidelity
- enable ACES filmic tone mapping with default exposure on the renderer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e458528c1c8327af3d6659807ae669