### PR TITLE
feat(ui): mount exposure slider in main

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { BuildingManager } from "./buildings/BuildingManager.js";
 import { PlayerController } from "./controls/PlayerController.js";
 import { Character } from "./characters/Character.js";
 import { spawnCitizenCrowd } from "./world/npcs.js";
+import { mountExposureSlider } from "./ui/exposureSlider.js";
 
 function isHtmlResponse(response) {
   const contentType = response.headers.get("content-type") || "";
@@ -110,6 +111,8 @@ async function mainApp() {
   configureRendererShadows(renderer);
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
+  // Mount the exposure control (F9 toggles visibility)
+  mountExposureSlider(renderer, { min: 0.2, max: 2.0, step: 0.01, key: "F9" });
   initializeAssetTranscoders(renderer);
   attachCrosshair();
 

--- a/src/ui/exposureSlider.js
+++ b/src/ui/exposureSlider.js
@@ -1,0 +1,1 @@
+export { mountExposureSlider } from "../UI/exposureSlider.js";


### PR DESCRIPTION
## Summary
- add the exposure slider import in the main entry point
- mount the exposure slider after configuring the renderer
- re-export the existing exposure slider module from the lowercase ui path used in main

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e45cf0cd748327b3a415fa7e0d84cb