### PR TITLE
feat(ui): add exposure slider (tone mapping) with F9 toggle

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -111,8 +111,19 @@ async function mainApp() {
   configureRendererShadows(renderer);
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
-  // Mount the exposure control (F9 toggles visibility)
-  mountExposureSlider(renderer, { min: 0.2, max: 2.0, step: 0.01, key: "F9" });
+  const shouldMountExposureSlider = (() => {
+    if (typeof import.meta !== "undefined" && import.meta?.env) {
+      if (typeof import.meta.env.DEV === "boolean") {
+        return import.meta.env.DEV;
+      }
+    }
+    return true;
+  })();
+
+  if (shouldMountExposureSlider) {
+    // Mount the exposure control (F9 toggles visibility)
+    mountExposureSlider(renderer, { min: 0.2, max: 2.0, step: 0.01, key: "F9" });
+  }
   initializeAssetTranscoders(renderer);
   attachCrosshair();
 


### PR DESCRIPTION
Adds src/ui/exposureSlider.js

Mounts slider in src/main.js (dev-only if Step 3 applied)

Lets you tweak renderer.toneMappingExposure live; persists in localStorage

------
https://chatgpt.com/codex/tasks/task_b_68e45dd933cc8327b535046772dd623e