### PR TITLE
Add generated Aristotle tomb glTF asset

### DIFF
--- a/docs/athens-game-starter/models/buildings/aristotle-tomb.gltf
+++ b/docs/athens-game-starter/models/buildings/aristotle-tomb.gltf
@@ -1,0 +1,101 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Placeholder conversion"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "AristotleTombScene",
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "AristotleTomb",
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "name": "AristotleTombMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "mode": 4,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "materials": [
+    {
+      "name": "PlaceholderMaterial",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.8,
+          0.8,
+          0.8,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.9
+      }
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAgD8AAAAAAAABAAIA",
+      "byteLength": 42
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 36,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 36,
+      "byteLength": 6,
+      "target": 34963
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "min": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "max": [
+        1.0,
+        1.0,
+        1.0
+      ]
+    },
+    {
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR",
+      "min": [
+        0
+      ],
+      "max": [
+        2
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the generated Aristotle tomb glTF placeholder asset to the docs output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e46806ddf883279e393e56c5308907