### PR TITLE
chore(dev): add hill-city debug overlay

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { createTerrain, updateTerrain } from "./world/terrain.js";
 import { createOcean, updateOcean } from "./world/ocean.js";
 import { createHarbor, updateHarborLighting } from "./world/harbor.js";
 import { createMainHillRoad, updateMainHillRoadLighting } from "./world/roads_hillcity.js";
+import { mountHillCityDebug } from "./world/debug_hillcity.js";
 import { createPlazas } from "./world/plazas.js";
 import { createCity, updateCityLighting, createHillCity } from "./world/city.js";
 import { CITY_CHUNK_CENTER, HARBOR_CENTER_3D } from "./world/locations.js";
@@ -215,6 +216,7 @@ async function mainApp() {
 
   // 1) Road from harbor → agora → acropolis
   const { group: roadGroup, curve: mainRoad } = createMainHillRoad(scene);
+  mountHillCityDebug(scene, mainRoad);
 
   // 2) Plazas (agora + acropolis terraces)
   const plazas = createPlazas(scene);

--- a/src/world/debug_hillcity.js
+++ b/src/world/debug_hillcity.js
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+
+export function mountHillCityDebug(scene, curve, opts = {}) {
+  if (!import.meta.env?.DEV) return null;
+
+  const g = new THREE.Group();
+  g.name = 'HillCityDebug';
+
+  // Curve line
+  if (curve) {
+    const pts = curve.getPoints(200);
+    const geo = new THREE.BufferGeometry().setFromPoints(pts.map(p => new THREE.Vector3(p.x, p.y + 0.05, p.z)));
+    const mat = new THREE.LineBasicMaterial({ color: 0x00aaff });
+    const line = new THREE.Line(geo, mat);
+    g.add(line);
+  }
+
+  // Simple axis marker at agora/acropolis provided by caller if desired...
+  scene.add(g);
+  return g;
+}


### PR DESCRIPTION
## Summary
- add a development-only hill city debug overlay that renders the main road curve
- mount the overlay in the main scene after creating the hill city road

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e47447890c8327bb67f2c4be43754d