### PR TITLE
Clamp hill city lots above sea level and drape road onto terrain

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,8 +11,8 @@ import { createHarbor, updateHarborLighting } from "./world/harbor.js";
 import { createMainHillRoad, updateMainHillRoadLighting } from "./world/roads_hillcity.js";
 import { mountHillCityDebug } from "./world/debug_hillcity.js";
 import { createPlazas } from "./world/plazas.js";
-import { createCity, updateCityLighting, createHillCity } from "./world/city.js";
-import { CITY_CHUNK_CENTER, HARBOR_CENTER_3D } from "./world/locations.js";
+import { updateCityLighting, createHillCity } from "./world/city.js";
+import { HARBOR_CENTER_3D } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
 import { InputMap } from "./input/InputMap.js";
@@ -210,12 +210,11 @@ async function mainApp() {
   const harbor = createHarbor(scene, { center: HARBOR_CENTER_3D });
   const envCollider = new EnvironmentCollider();
   scene.add(envCollider.mesh);
-  const city = createCity(scene, terrain, {
-    origin: CITY_CHUNK_CENTER,
-  });
+  // const city = createCity(scene, terrain, { origin: CITY_CHUNK_CENTER });
+  const city = null;
 
   // 1) Road from harbor → agora → acropolis
-  const { group: roadGroup, curve: mainRoad } = createMainHillRoad(scene);
+  const { group: roadGroup, curve: mainRoad } = createMainHillRoad(scene, terrain);
   mountHillCityDebug(scene, mainRoad);
 
   // 2) Plazas (agora + acropolis terraces)
@@ -389,6 +388,7 @@ async function mainApp() {
       count: 8,
       minSpeed: 0.7,
       maxSpeed: 1.4,
+      terrain,
     });
     npcUpdaters.push(...crowd.updaters);
   }

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -12,16 +12,16 @@ export const SEA_LEVEL_Y =
 
 // Key anchors
 export const HARBOR_CENTER_3D = new THREE.Vector3(-120, SEA_LEVEL_Y, 80);
-export const ACROPOLIS_PEAK_3D = new THREE.Vector3(-40, 12, 10); // elevated inland focal point
-export const AGORA_CENTER_3D = new THREE.Vector3(-80, 6, 40); // mid-terrace civic plaza
+export const ACROPOLIS_PEAK_3D = new THREE.Vector3(-40, 14, 10); // elevated inland focal point
+export const AGORA_CENTER_3D = new THREE.Vector3(-80, 8, 40); // mid-terrace civic plaza
 
 // Zones (radius in world units)
-export const HARBOR_EXCLUDE_RADIUS = 70; // keep water clear
+export const HARBOR_EXCLUDE_RADIUS = 110; // keep water clear
 export const AGORA_RADIUS = 22; // flat(ish) plaza
 export const ACROPOLIS_RADIUS = 18; // temple/council terrace
 
 // Terrain/placement rules
-export const MIN_ABOVE_SEA = 1.0; // buildings must be above water by this margin
+export const MIN_ABOVE_SEA = 2.0; // buildings must be above water by this margin
 export const MAX_SLOPE_DELTA = 0.35; // max allowed height change over ~1m sample
 export const CITY_AREA_RADIUS = 180; // overall distribution radius
 

--- a/src/world/npcs.js
+++ b/src/world/npcs.js
@@ -54,6 +54,7 @@ export function spawnCitizenCrowd(scene, pathCurve, options = {}) {
   const count = options.count ?? 6;
   const minSpeed = options.minSpeed ?? 0.6;
   const maxSpeed = options.maxSpeed ?? 1.2;
+  const terrain = options.terrain ?? null;
   const palette = options.palette ?? [
     { primary: 0x4e8ef7, secondary: 0xf5f5f5 },
     { primary: 0xf06292, secondary: 0xffecb3 },
@@ -63,6 +64,7 @@ export function spawnCitizenCrowd(scene, pathCurve, options = {}) {
   ];
 
   const { totalLength } = createCurveLengthLookup(pathCurve);
+  const heightSampler = terrain?.userData?.getHeightAt;
 
   const citizens = [];
   const updaters = [];
@@ -88,7 +90,14 @@ export function spawnCitizenCrowd(scene, pathCurve, options = {}) {
       const tangent = pathCurve.getTangentAt(progress);
 
       group.position.copy(position);
-      group.position.y += 0.05;
+      let groundY = position.y;
+      if (typeof heightSampler === 'function') {
+        const sampled = heightSampler(group.position.x, group.position.z);
+        if (Number.isFinite(sampled)) {
+          groundY = sampled;
+        }
+      }
+      group.position.y = groundY + 0.05;
 
       const yaw = Math.atan2(tangent.x, tangent.z);
       group.rotation.set(0, yaw, 0);


### PR DESCRIPTION
## Summary
- disable the legacy grid city spawn and plumb terrain references into the road and NPC systems so they conform to ground height
- tighten shoreline placement rules for the hill city, expanding harbor exclusion radius and enforcing a higher minimum elevation
- resample terrain for every hill-city lot while accounting for lot radius near the harbor and drape the main road along the sampled terrain

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e474d3cff48327b8df22ad1a080961