### PR TITLE
Align civic district with terrain height

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ import { createMainHillRoad, updateMainHillRoadLighting } from "./world/roads_hi
 import { mountHillCityDebug } from "./world/debug_hillcity.js";
 import { createPlazas } from "./world/plazas.js";
 import { updateCityLighting, createHillCity } from "./world/city.js";
-import { HARBOR_CENTER_3D } from "./world/locations.js";
+import { AGORA_CENTER_3D, HARBOR_CENTER_3D } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
 import { InputMap } from "./input/InputMap.js";
@@ -233,6 +233,8 @@ async function mainApp() {
     plazaLength: 90,
     promenadeWidth: 16,
     greensWidth: 9,
+    center: AGORA_CENTER_3D,
+    terrain,
   });
 
   const input = new InputMap(renderer.domElement);


### PR DESCRIPTION
## Summary
- extend the civic district builder to accept a center and terrain sampler so it can determine local ground height
- offset promenade, plazas, buildings, lamps, and walking path control points to the sampled elevation to keep assets on the hillside
- create the civic district at the agora center while providing the terrain sampler from main.js

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e47385858083279fc671778d54305d