### PR TITLE
Fix harbor water bounds and clipping

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -117,6 +117,7 @@ async function mainApp() {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
   renderer.toneMappingExposure = 1.0;
+  renderer.localClippingEnabled = true;
   configureRendererShadows(renderer);
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);

--- a/src/world/city.js
+++ b/src/world/city.js
@@ -261,10 +261,10 @@ export function createHillCity(scene, terrain, curve, opts = {}) {
     seed = 20251007,
     buildingCount = 140,
     spacing = 5.5,
-    harborBand = [SEA_LEVEL_Y + 3.0, SEA_LEVEL_Y + 5.5], // +1m headroom near water
+    harborBand = [SEA_LEVEL_Y + 3.5, SEA_LEVEL_Y + 6.0], // +1m headroom near water
     agoraBand = [SEA_LEVEL_Y + 3.0, SEA_LEVEL_Y + 8.0],
     acroBand = [SEA_LEVEL_Y + 7.0, SEA_LEVEL_Y + 14.0],
-    avoidHarborRadius = HARBOR_EXCLUDE_RADIUS + 18,
+    avoidHarborRadius = HARBOR_EXCLUDE_RADIUS + 24,
   } = opts;
 
   const rng = makeRng(seed);

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -36,6 +36,16 @@ export const CITY_CHUNK_SIZE = new THREE.Vector2(72, 54);
 export const CITY_SEED = 0x4d534349;
 
 // Harbor water extents (limit the ocean to the bay only)
-export const HARBOR_WATER_CENTER = HARBOR_CENTER_3D.clone(); // same XZ as harbor
-export const HARBOR_WATER_SIZE = new THREE.Vector2(320, 240); // width (X), depth (Z) in world units
 export const HARBOR_WATER_RADIUS = 170; // if using circular water
+
+// Harbor water extents (rectangle) and seaward offset
+export const HARBOR_WATER_SIZE = new THREE.Vector2(260, 180); // width (X), depth (Z)
+export const HARBOR_WATER_OFFSET = new THREE.Vector2(0, -60); // push water toward open sea (−Z)
+export const HARBOR_WATER_BACK = 40; // max inland distance allowed (in Z half-extent)
+
+// Convenience centers
+export const HARBOR_WATER_CENTER = new THREE.Vector3(
+  HARBOR_CENTER_3D.x + HARBOR_WATER_OFFSET.x,
+  SEA_LEVEL_Y,
+  HARBOR_CENTER_3D.z + HARBOR_WATER_OFFSET.y
+);

--- a/src/world/ocean.js
+++ b/src/world/ocean.js
@@ -1,9 +1,9 @@
 import * as THREE from "three";
 import { Water } from "three/addons/objects/Water.js";
 import {
-  HARBOR_SEA_LEVEL,
   HARBOR_WATER_CENTER,
   HARBOR_WATER_SIZE,
+  HARBOR_WATER_BACK,
 } from "./locations.js";
 
 function generateNormalComponent(x, y, octave) {
@@ -68,143 +68,21 @@ function computeRenderTargetSize(options) {
   return THREE.MathUtils.clamp(size, 256, 2048);
 }
 
-function resolveVector3(option, fallback = new THREE.Vector3()) {
-  if (option instanceof THREE.Vector3) {
-    return option.clone();
-  }
-  if (option && typeof option === "object") {
-    const { x, y, z } = option;
-    return new THREE.Vector3(
-      Number.isFinite(x) ? x : fallback.x,
-      Number.isFinite(y) ? y : fallback.y,
-      Number.isFinite(z) ? z : fallback.z
-    );
-  }
-  return fallback.clone();
-}
-
-function resolveSize(option, fallback = 800) {
-  if (typeof option === "number" && Number.isFinite(option) && option > 0) {
-    return { width: option, depth: option };
-  }
-  if (Array.isArray(option) && option.length > 0) {
-    const width = option[0];
-    const depth = option.length > 1 ? option[1] : option[0];
-    return {
-      width: Number.isFinite(width) && width > 0 ? width : fallback,
-      depth: Number.isFinite(depth) && depth > 0 ? depth : fallback,
-    };
-  }
-  if (option && typeof option === "object") {
-    const width = option.width ?? option.x ?? option.w;
-    const depth = option.depth ?? option.height ?? option.z ?? option.y ?? option.h;
-    return {
-      width: Number.isFinite(width) && width > 0 ? width : fallback,
-      depth: Number.isFinite(depth) && depth > 0 ? depth : fallback,
-    };
-  }
-  return { width: fallback, depth: fallback };
-}
-
-function resolveBounds(bounds, defaults) {
-  if (!bounds || typeof bounds !== "object") {
-    return null;
-  }
-
-  const hasWest = Number.isFinite(bounds.west);
-  const hasEast = Number.isFinite(bounds.east);
-  const hasSouth = Number.isFinite(bounds.south);
-  const hasNorth = Number.isFinite(bounds.north);
-
-  if (!hasWest && !hasEast && !hasSouth && !hasNorth) {
-    return null;
-  }
-
-  const resolved = {
-    west: hasWest
-      ? bounds.west
-      : hasEast
-      ? bounds.east - defaults.width
-      : defaults.centerX - defaults.width * 0.5,
-    east: 0,
-    south: hasSouth
-      ? bounds.south
-      : hasNorth
-      ? bounds.north - defaults.depth
-      : defaults.centerZ - defaults.depth * 0.5,
-    north: 0,
-  };
-
-  resolved.east = hasEast ? bounds.east : resolved.west + defaults.width;
-  resolved.north = hasNorth ? bounds.north : resolved.south + defaults.depth;
-
-  return resolved;
-}
-
 export async function createOcean(scene, options = {}) {
-  const size = resolveSize(options.size, 800);
-  const position = resolveVector3(options.position, new THREE.Vector3());
-  const defaults = {
-    width: size.width,
-    depth: size.depth,
-    centerX: position.x,
-    centerZ: position.z,
-  };
-  const bounds = resolveBounds(options.bounds, defaults);
-  const resolvedWidth = bounds
-    ? Math.max(1, Math.abs(bounds.east - bounds.west))
-    : size.width;
-  const resolvedDepth = bounds
-    ? Math.max(1, Math.abs(bounds.north - bounds.south))
-    : size.depth;
-
-  if (bounds) {
-    position.x = (bounds.west + bounds.east) * 0.5;
-    position.z = (bounds.south + bounds.north) * 0.5;
-  }
-
   if (!cachedNormals) {
     cachedNormals = createProceduralWaterNormals();
   }
 
   const renderTargetSize = computeRenderTargetSize(options);
 
-  let width = HARBOR_WATER_SIZE.x;
-  let depth = HARBOR_WATER_SIZE.y;
-  const terrainBounds = options?.terrain?.userData?.bounds;
-  if (terrainBounds) {
-    const minX = terrainBounds.minX;
-    const maxX = terrainBounds.maxX;
-    const minZ = terrainBounds.minZ;
-    const maxZ = terrainBounds.maxZ;
+  // remove prior water meshes if any
+  scene.traverse((o) => {
+    if (o && (o.name === "AegeanOcean" || o.userData?.isWater)) {
+      o.parent?.remove(o);
+    }
+  });
 
-    const halfWidth = width * 0.5;
-    let maxHalfWidth = halfWidth;
-    if (Number.isFinite(maxX)) {
-      maxHalfWidth = Math.min(maxHalfWidth, Math.max(0, maxX - HARBOR_WATER_CENTER.x));
-    }
-    if (Number.isFinite(minX)) {
-      maxHalfWidth = Math.min(maxHalfWidth, Math.max(0, HARBOR_WATER_CENTER.x - minX));
-    }
-    width = Math.max(1, maxHalfWidth * 2);
-
-    const halfDepth = depth * 0.5;
-    let maxHalfDepth = halfDepth;
-    if (Number.isFinite(maxZ)) {
-      maxHalfDepth = Math.min(maxHalfDepth, Math.max(0, maxZ - HARBOR_WATER_CENTER.z));
-    }
-    if (Number.isFinite(minZ)) {
-      maxHalfDepth = Math.min(maxHalfDepth, Math.max(0, HARBOR_WATER_CENTER.z - minZ));
-    }
-    depth = Math.max(1, maxHalfDepth * 2);
-  }
-
-  const geometry = new THREE.PlaneGeometry(
-    width,
-    depth,
-    1,
-    1
-  );
+  const geometry = new THREE.PlaneGeometry(HARBOR_WATER_SIZE.x, HARBOR_WATER_SIZE.y, 1, 1);
   const water = new Water(geometry, {
     textureWidth: renderTargetSize,
     textureHeight: renderTargetSize,
@@ -217,17 +95,38 @@ export async function createOcean(scene, options = {}) {
   });
 
   water.rotation.x = -Math.PI / 2;
-  water.position.set(
-    HARBOR_WATER_CENTER.x,
-    HARBOR_SEA_LEVEL,
-    HARBOR_WATER_CENTER.z
-  );
-
+  water.position.copy(HARBOR_WATER_CENTER);
   water.receiveShadow = true;
-  water.renderOrder = -1;
-  if (water.material) water.material.depthWrite = true;
   water.name = "AegeanOcean";
   water.userData.noCollision = true;
+  water.userData.isWater = true;
+
+  // Draw behind world but still write depth
+  water.renderOrder = -1;
+  if (water.material) {
+    water.material.depthWrite = true;
+    water.material.transparent = true;
+  }
+
+  // Build 4 clipping planes around the rectangle
+  const halfX = HARBOR_WATER_SIZE.x * 0.5;
+  const halfZFront = HARBOR_WATER_SIZE.y * 0.5;
+  const halfZBack = Math.min(HARBOR_WATER_BACK, halfZFront);
+
+  const cx = HARBOR_WATER_CENTER.x;
+  const cz = HARBOR_WATER_CENTER.z;
+
+  const planes = [
+    new THREE.Plane(new THREE.Vector3(1, 0, 0), -(cx - halfX)),
+    new THREE.Plane(new THREE.Vector3(-1, 0, 0), cx + halfX),
+    new THREE.Plane(new THREE.Vector3(0, 0, 1), -(cz + halfZBack)),
+    new THREE.Plane(new THREE.Vector3(0, 0, -1), cz - halfZFront),
+  ];
+
+  if (water.material) {
+    water.material.clipping = true;
+    water.material.clippingPlanes = planes;
+  }
 
   scene.add(water);
 

--- a/src/world/roads.js
+++ b/src/world/roads.js
@@ -93,6 +93,7 @@ export function createRoad(parent, points, options = {}) {
   mesh.receiveShadow = true;
   mesh.castShadow = false;
   mesh.userData.noCollision = options.noCollision ?? true;
+  mesh.renderOrder = 1;
 
   if (parent) {
     parent.add(mesh);


### PR DESCRIPTION
## Summary
- add explicit harbor water sizing constants including offset and inland cutoff
- rebuild the ocean mesh creation to enforce a single clipped water plane and enable renderer clipping
- keep paved roads above the water and adjust shoreline building placement clearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4b7c710d48327a2b000b5d5d5307b