### PR TITLE
Fix terrain sampling and align hill city to ground

### DIFF
--- a/src/world/roads_hillcity.js
+++ b/src/world/roads_hillcity.js
@@ -31,7 +31,7 @@ export function createMainHillRoad(scene, terrain) {
   const dir = new THREE.Vector3();
 
   // helper for height sampling
-  const getH = (x, z) => terrain?.userData?.getHeightAt?.(x, z);
+  const getH = terrain?.userData?.getHeightAt?.bind(terrain?.userData);
 
   for (let i = 0; i <= segments; i++) {
     const t = i / segments;
@@ -49,7 +49,7 @@ export function createMainHillRoad(scene, terrain) {
       );
       const x = p.x + dir.x;
       const z = p.z + dir.z;
-      let y = getH?.(x, z);
+      let y = getH ? getH(x, z) : p.y;
       if (!Number.isFinite(y)) y = p.y;
       y += 0.03; // small lift to avoid z-fighting with ground
       pos.setXYZ(idx / 3, x, y, z);

--- a/src/world/terrainHeight.js
+++ b/src/world/terrainHeight.js
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+/**
+ * Ensures terrain.userData.getHeightAt(x,z) exists.
+ * Uses raycast from above if no native sampler is provided.
+ */
+export function attachHeightSampler(terrain, scene) {
+  if (!terrain) return;
+
+  // If a sampler already exists and returns a number, keep it
+  const existing = terrain?.userData?.getHeightAt;
+  if (existing && Number.isFinite(existing(0,0))) return;
+
+  const raycaster = new THREE.Raycaster();
+  raycaster.firstHitOnly = true;
+
+  const targets = [terrain]; // you can add other ground meshes here if needed
+  const UP = 200, DOWN = -400;
+
+  function getHeightAt(x, z) {
+    // Cast from high above downwards
+    const origin = new THREE.Vector3(x, UP, z);
+    const dir = new THREE.Vector3(0, -1, 0);
+    raycaster.set(origin, dir);
+    const hit = raycaster.intersectObjects(targets, true)[0];
+    if (hit) return hit.point.y;
+    // Fallback: try upwards (for cases when cast started below)
+    const origin2 = new THREE.Vector3(x, DOWN, z);
+    const dir2 = new THREE.Vector3(0, 1, 0);
+    raycaster.set(origin2, dir2);
+    const hit2 = raycaster.intersectObjects(targets, true)[0];
+    return hit2 ? hit2.point.y : 0; // safe default
+  }
+
+  terrain.userData = terrain.userData || {};
+  terrain.userData.getHeightAt = getHeightAt;
+}


### PR DESCRIPTION
## Summary
- add a raycast-backed terrain height sampler and wire it up during scene creation
- drape the main hill road over sampled terrain heights so it renders cleanly above water
- clamp hill-city lots and buildings to the ground with slope filtering, dedupe lots, and widen harbor safety bands

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4b9fb0b908327b5bf20b58fecd492