### PR TITLE
Fix hill city lighting update reference

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -236,7 +236,7 @@ async function mainApp() {
   createPlazas(scene);
 
   // Hill-city buildings (uses terrain sampler + road curve)
-  createHillCity(scene, terrain, mainRoad, {
+  const hillCity = createHillCity(scene, terrain, mainRoad, {
     seed: 42,
     buildingCount: 140,
   });
@@ -556,7 +556,7 @@ async function mainApp() {
     updateSky(skyObj, sunDir);
     updateLighting(lights, sunDir);
     updateHarborLighting(harbor, lights.nightFactor);
-    updateCityLighting(city, lights.nightFactor);
+    updateCityLighting(hillCity, lights.nightFactor);
     updateMainHillRoadLighting(roadGroup, lights.nightFactor);
     // Fade the stars in and out depending on the time of day.
     updateStars(stars, phase);


### PR DESCRIPTION
## Summary
- store the hill city group returned by createHillCity
- pass the stored hill city group into updateCityLighting to avoid a missing reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4bc92f6c0832783b6913348c630a5