### PR TITLE
Fix undefined road group reference in main app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -226,7 +226,7 @@ async function mainApp() {
   scene.add(envCollider.mesh);
 
   // Roads first (needs terrain sampler)
-  const { curve: mainRoad } = createMainHillRoad(scene, terrain);
+  const { group: roadGroup, curve: mainRoad } = createMainHillRoad(scene, terrain);
   if (import.meta.env?.DEV) {
     mountHillCityDebug(scene, mainRoad);
   }


### PR DESCRIPTION
## Summary
- capture the road group returned by createMainHillRoad so lighting updates no longer reference an undefined variable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4c5d3a6b4832785a09ab4c2249b21