### PR TITLE
feat: refine hotkey overlay toggle

### DIFF
--- a/src/ui/hotkeyOverlay.js
+++ b/src/ui/hotkeyOverlay.js
@@ -1,6 +1,23 @@
 const STYLE_ID = "hotkey-overlay-style";
 const ROOT_CLASS = "hotkey-overlay";
 const HIDDEN_MOD = "hotkey-overlay--hidden";
+const STORAGE_KEY = "hotkeyOverlayOpen";
+
+function loadOpenState() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveOpenState(isOpen) {
+  try {
+    localStorage.setItem(STORAGE_KEY, isOpen ? "1" : "0");
+  } catch {
+    // ignore write errors (e.g., storage disabled)
+  }
+}
 
 const DEFAULT_HOTKEYS = [
   { keys: ["W", "A", "S", "D"], description: "Move" },
@@ -17,6 +34,7 @@ const DEFAULT_HOTKEYS = [
  * @typedef {{
  *  hotkeys?: { keys: string[]; description: string }[];
  *  toggleKey?: string;
+ *  showButton?: boolean;
  * }} HotkeyOverlayOptions
  */
 
@@ -40,15 +58,24 @@ export function mountHotkeyOverlay(options = {}) {
     ? options.toggleKey
     : "KeyH";
 
+  const showButton = options.showButton !== false;
+
   const root = document.createElement("div");
-  root.className = `${ROOT_CLASS} ${HIDDEN_MOD}`;
+  root.className = ROOT_CLASS;
   root.setAttribute("role", "dialog");
   root.setAttribute("aria-live", "polite");
 
   const toggleButton = document.createElement("button");
   toggleButton.type = "button";
   toggleButton.className = `${ROOT_CLASS}__toggle`;
-  toggleButton.textContent = "Hotkeys";
+  toggleButton.innerHTML = `
+    <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="currentColor"
+        d="M3 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-6l-3.5 3.5a1 1 0 0 1-1.7-.7V17H6a3 3 0 0 1-3-3V6zm4 2a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2H7zm5 0a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2h-2zm5 0a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2h-2z"/>
+    </svg>
+    <span class="${ROOT_CLASS}__sr">Hotkeys (press ${resolveKeyLabel(toggleKey)})</span>
+  `;
+  toggleButton.setAttribute("title", `Hotkeys (${resolveKeyLabel(toggleKey)})`);
   toggleButton.setAttribute("aria-expanded", "false");
   toggleButton.setAttribute("aria-controls", `${ROOT_CLASS}-panel`);
 
@@ -95,29 +122,54 @@ export function mountHotkeyOverlay(options = {}) {
   hint.textContent = `Press ${resolveKeyLabel(toggleKey)} to toggle`;
   panel.appendChild(hint);
 
+  const initialOpen = loadOpenState();
+  if (!initialOpen) {
+    root.classList.add(HIDDEN_MOD);
+  } else {
+    root.classList.remove(HIDDEN_MOD);
+  }
+
+  if (showButton) {
+    root.appendChild(toggleButton);
+  }
   root.appendChild(panel);
-  root.appendChild(toggleButton);
   document.body.appendChild(root);
 
-  const updateVisibility = (show) => {
-    const shouldShow = show ?? root.classList.contains(HIDDEN_MOD);
-    if (shouldShow) {
+  const applyVisibility = (shouldOpen) => {
+    if (shouldOpen) {
       root.classList.remove(HIDDEN_MOD);
     } else {
       root.classList.add(HIDDEN_MOD);
     }
     const isOpen = !root.classList.contains(HIDDEN_MOD);
-    toggleButton.setAttribute("aria-expanded", String(isOpen));
+    toggleButton?.setAttribute?.("aria-expanded", String(isOpen));
     panel.setAttribute("aria-hidden", String(!isOpen));
+    saveOpenState(isOpen);
   };
 
-  toggleButton.addEventListener("click", () => {
-    updateVisibility();
-  });
+  applyVisibility(initialOpen);
+
+  const updateVisibility = (toggle) => {
+    if (toggle === true) {
+      applyVisibility(root.classList.contains(HIDDEN_MOD));
+      return;
+    }
+    if (toggle === false) {
+      applyVisibility(false);
+      return;
+    }
+    applyVisibility(!root.classList.contains(HIDDEN_MOD));
+  };
+
+  if (showButton) {
+    toggleButton.addEventListener("click", () => {
+      updateVisibility(true);
+    });
+  }
 
   window.addEventListener("keydown", (event) => {
     if (event.code === toggleKey && !event.repeat) {
-      updateVisibility();
+      updateVisibility(true);
     }
     if (event.code === "Escape" && !root.classList.contains(HIDDEN_MOD)) {
       updateVisibility(false);
@@ -135,43 +187,51 @@ function ensureStyles() {
   style.textContent = `
     .${ROOT_CLASS} {
       position: fixed;
-      left: 16px;
-      bottom: 16px;
-      z-index: 1100;
+      right: 16px;
+      top: 16px;
+      z-index: 1200;
       display: flex;
-      flex-direction: column-reverse;
-      gap: 12px;
+      flex-direction: column;
+      gap: 10px;
       color: #fff;
-      font-family: 'Inter', 'Segoe UI', sans-serif;
+      font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    }
+
+    .${ROOT_CLASS}__sr {
+      position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+      overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
     }
 
     .${ROOT_CLASS}__toggle {
-      background: rgba(0, 0, 0, 0.7);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-radius: 6px;
+      background: rgba(0,0,0,0.5);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 999px;
       color: inherit;
-      font: inherit;
-      padding: 6px 12px;
+      width: 28px; height: 28px;
+      display: grid; place-items: center;
+      padding: 0;
       cursor: pointer;
-      transition: background 0.2s ease, border-color 0.2s ease;
+      transition: background .2s ease, border-color .2s ease, opacity .2s ease, transform .12s ease;
+      opacity: .85;
     }
-
     .${ROOT_CLASS}__toggle:hover,
     .${ROOT_CLASS}__toggle:focus-visible {
-      background: rgba(0, 0, 0, 0.85);
-      border-color: rgba(255, 255, 255, 0.4);
+      background: rgba(0,0,0,0.72);
+      border-color: rgba(255,255,255,0.36);
       outline: none;
+      opacity: 1;
+      transform: scale(1.04);
     }
 
     .${ROOT_CLASS}__panel {
-      background: rgba(10, 12, 18, 0.9);
-      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(10,12,18,0.9);
+      border: 1px solid rgba(255,255,255,0.12);
       border-radius: 10px;
-      padding: 16px;
+      padding: 14px;
       min-width: 220px;
       backdrop-filter: blur(6px);
-      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
-      transition: opacity 0.2s ease, transform 0.2s ease;
+      box-shadow: 0 12px 30px rgba(0,0,0,0.35);
+      transition: opacity .18s ease, transform .18s ease;
     }
 
     .${ROOT_CLASS}__title {
@@ -211,7 +271,13 @@ function ensureStyles() {
     .${ROOT_CLASS}.${HIDDEN_MOD} .${ROOT_CLASS}__panel {
       opacity: 0;
       pointer-events: none;
-      transform: translateY(8px);
+      transform: translateY(-6px);
+    }
+
+    /* Hide the icon while the panel is open (less clutter) */
+    .${ROOT_CLASS}:not(.${HIDDEN_MOD}) .${ROOT_CLASS}__toggle {
+      opacity: 0;
+      pointer-events: none;
     }
   `;
 


### PR DESCRIPTION
## Summary
- restyle the hotkey overlay toggle into a compact keyboard icon in the top-right corner
- add optional `showButton` support and persist panel visibility state in localStorage
- smooth out overlay animations and hide the icon while the panel is open

## Testing
- npm ci
- npm run build
- npm run dev


------
https://chatgpt.com/codex/tasks/task_b_68e4d500dfd883278547c4eeaa3b2303