### PR TITLE
fix(ocean): correct Z clip plane orientation; pad scaling; HUD override

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -631,8 +631,10 @@ async function mainApp() {
 
   // Mount HUD in dev OR if a global flag is set (useful in prod previews)
   const SHOW_HUD =
-    (typeof window !== "undefined" && window.SHOW_HUD === true) ||
-    import.meta.env?.DEV;
+    import.meta.env?.DEV ||
+    (typeof window !== "undefined" &&
+      (window.SHOW_HUD === true ||
+        new URLSearchParams(window.location.search).has("hud")));
   if (SHOW_HUD) {
     console.log("[HUD] mounting…");
     mountDevHUD({ getPosition, getDirection, onPin });

--- a/src/world/city.js
+++ b/src/world/city.js
@@ -344,12 +344,14 @@ export function createHillCity(scene, terrain, curve, opts = {}) {
     const ySample = getH ? getH(p.x, p.z) : p.y;
     const baseY = Math.max(Number.isFinite(ySample) ? ySample : p.y, SEA_LEVEL_Y + MIN_ABOVE_SEA);
 
-    addFoundationPad(scene, p.x, baseY, p.z, 2.2);
+    const buildingScale = 0.9 + rng() * 0.3;
+    const padRadius = Math.max(2.0, 1.8 * buildingScale);
+    addFoundationPad(scene, p.x, baseY, p.z, padRadius);
 
     // walls
     dummy.position.set(p.x, baseY + 1.0, p.z);
     dummy.rotation.set(0, yaw, 0);
-    dummy.scale.setScalar(0.9 + rng() * 0.3);
+    dummy.scale.setScalar(buildingScale);
     dummy.updateMatrix();
     walls.setMatrixAt(i, dummy.matrix);
 

--- a/src/world/ocean.js
+++ b/src/world/ocean.js
@@ -106,13 +106,15 @@ export async function createOcean(scene, options = {}) {
   const planes = [
     new THREE.Plane(new THREE.Vector3(1, 0, 0), -(cx - halfX)), // left:  x >= cx - halfX
     new THREE.Plane(new THREE.Vector3(-1, 0, 0), cx + halfX), // right: x <= cx + halfX
-    new THREE.Plane(new THREE.Vector3(0, 0, 1), -(cz + halfZBack)), // back (inland):  z <= cz + 0
-    new THREE.Plane(new THREE.Vector3(0, 0, -1), cz - halfZFront), // front (sea):    z >= cz - halfZFront
+    // back (inland limit)
+    new THREE.Plane(new THREE.Vector3(0, 0, -1), cz + halfZBack),
+    // front (sea)
+    new THREE.Plane(new THREE.Vector3(0, 0, 1), -(cz - halfZFront)),
   ];
 
   if (water.material) {
-    water.material.clipping = true;
     water.material.clippingPlanes = planes;
+    water.material.clipIntersection = true;
     water.material.depthWrite = true;
     water.material.transparent = true;
     water.material.needsUpdate = true;


### PR DESCRIPTION
## Summary
- correct the ocean clipping planes so inland water is culled while retaining the harbor view
- scale hill city foundation pads relative to the randomized building size for better alignment
- allow the HUD to be toggled in production via the `?hud=1` query parameter

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4eaed82b483278953eb9b5e5ddb05