### PR TITLE
Handle audio asset paths relative to Vite base

### DIFF
--- a/public/audio/README.md
+++ b/public/audio/README.md
@@ -2,6 +2,11 @@
 
 Drop optional royalty-free or CC0 audio loops/one-shots in this folder.
 
+The default build only bundles the clips that actually ship with the
+repository (currently the sea ambience and gulls loop). Any additional
+files you add locally can be referenced from `manifest.json` to enable them
+in the game without modifying the code.
+
 Expected filenames:
 
 - `ambient_sea.ogg` – gentle shore/waves ambience

--- a/public/audio/manifest.json
+++ b/public/audio/manifest.json
@@ -2,15 +2,15 @@
   "ambient": {
     "sea": "audio/ambient_sea.ogg",
     "gulls": "audio/gulls.ogg",
-    "wind": "audio/wind.ogg",
-    "fountain": "audio/fountain.ogg",
-    "lyre": "audio/lyre.ogg",
-    "market": "audio/market_chatter.ogg"
+    "wind": null,
+    "fountain": null,
+    "lyre": null,
+    "market": null
   },
   "effects": {
-    "blacksmith": "audio/blacksmith.ogg",
-    "goats": "audio/goats.ogg",
-    "cart": "audio/cart.ogg",
-    "footsteps": "audio/footsteps.ogg"
+    "blacksmith": null,
+    "goats": null,
+    "cart": null,
+    "footsteps": null
   }
 }

--- a/src/audio/soundscape.js
+++ b/src/audio/soundscape.js
@@ -120,26 +120,40 @@ export class Soundscape {
   }
 
   async initFromManifest(manifestUrl = "audio/manifest.json") {
+    const resolveAssetPath = (path) => {
+      if (!path) return path;
+      const ABSOLUTE = /^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|\/)/;
+      if (ABSOLUTE.test(path)) return path;
+      const base = import.meta?.env?.BASE_URL ?? "/";
+      const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+      const normalizedPath = path.replace(/^\.?\//, "");
+      return `${normalizedBase}${normalizedPath}`;
+    };
+
+    const resolvedManifestUrl = resolveAssetPath(manifestUrl);
     let mf;
     try {
-      mf = await (await fetch(manifestUrl)).json();
+      mf = await (await fetch(resolvedManifestUrl)).json();
     } catch {
       console.warn("[audio] manifest.json not found. Using default empty manifest.");
       mf = { ambient: {}, effects: {} };
     }
 
+    const ambient = mf.ambient ?? {};
+    const effects = mf.effects ?? {};
+
     // Ambient layers
-    const sea = await this.loadBuffer("sea", mf.ambient.sea);
-    const gulls = await this.loadBuffer("gulls", mf.ambient.gulls);
-    const wind = await this.loadBuffer("wind", mf.ambient.wind);
-    const market = await this.loadBuffer("market", mf.ambient.market);
-    const fountain = await this.loadBuffer("fountain", mf.ambient.fountain);
-    const lyre = await this.loadBuffer("lyre", mf.ambient.lyre);
+    const sea = await this.loadBuffer("sea", resolveAssetPath(ambient.sea));
+    const gulls = await this.loadBuffer("gulls", resolveAssetPath(ambient.gulls));
+    const wind = await this.loadBuffer("wind", resolveAssetPath(ambient.wind));
+    const market = await this.loadBuffer("market", resolveAssetPath(ambient.market));
+    const fountain = await this.loadBuffer("fountain", resolveAssetPath(ambient.fountain));
+    const lyre = await this.loadBuffer("lyre", resolveAssetPath(ambient.lyre));
 
     // Effects / one-shots
-    const blacksmith = await this.loadBuffer("blacksmith", mf.effects.blacksmith);
-    const goats = await this.loadBuffer("goats", mf.effects.goats);
-    const cart = await this.loadBuffer("cart", mf.effects.cart);
+    const blacksmith = await this.loadBuffer("blacksmith", resolveAssetPath(effects.blacksmith));
+    const goats = await this.loadBuffer("goats", resolveAssetPath(effects.goats));
+    const cart = await this.loadBuffer("cart", resolveAssetPath(effects.cart));
 
     // Global ambient: sea + wind (wind mixed more at night)
     this._makeGlobal(sea, "ambience", { volume: 0.25 })?.play();


### PR DESCRIPTION
## Summary
- resolve manifest and audio file URLs against Vite's base path so optional clips load correctly in production
- update the default audio manifest and README to only reference the clips that ship with the repository while documenting how to add more locally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4f804e38c83279fa48c359abe2cec