### PR TITLE
Limit harbor water to west side of the pier

### DIFF
--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -41,6 +41,8 @@ export const HARBOR_WATER_RADIUS = 170; // if using circular water
 // Harbor water extents (rectangle) and seaward offset
 export const HARBOR_WATER_SIZE = new THREE.Vector2(260, 100); // reduce Z extent (depth)
 export const HARBOR_WATER_OFFSET = new THREE.Vector2(0, -100); // push water toward open sea (−Z)
+// Keep the harbor water strictly on the seaward (western) side of the pier
+export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - 4.5; // align with pier edge
 export const HARBOR_WATER_BACK = 0; // max inland distance allowed (in Z half-extent)
 
 // Convenience centers

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -43,7 +43,7 @@ export const HARBOR_WATER_SIZE = new THREE.Vector2(260, 100); // reduce Z extent
 export const HARBOR_WATER_OFFSET = new THREE.Vector2(0, -100); // push water toward open sea (−Z)
 // Keep the harbor water strictly on the seaward (western) side of the pier
 export const PIER_EDGE_OFFSET = 4.5; // distance from harbor center to pier edge
-export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - PIER_EDGE_OFFSET; // align with pier edge
+export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - PIER_EDGE_OFFSET; // align with western (seaward) edge of pier
 export const HARBOR_WATER_BACK = 0; // max inland distance allowed (in Z half-extent)
 
 // Convenience centers

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -42,7 +42,8 @@ export const HARBOR_WATER_RADIUS = 170; // if using circular water
 export const HARBOR_WATER_SIZE = new THREE.Vector2(260, 100); // reduce Z extent (depth)
 export const HARBOR_WATER_OFFSET = new THREE.Vector2(0, -100); // push water toward open sea (−Z)
 // Keep the harbor water strictly on the seaward (western) side of the pier
-export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - 4.5; // align with pier edge
+export const PIER_EDGE_OFFSET = 4.5; // distance from harbor center to pier edge
+export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - PIER_EDGE_OFFSET; // align with pier edge
 export const HARBOR_WATER_BACK = 0; // max inland distance allowed (in Z half-extent)
 
 // Convenience centers

--- a/src/world/ocean.js
+++ b/src/world/ocean.js
@@ -107,7 +107,9 @@ export async function createOcean(scene, options = {}) {
   const cx = HARBOR_WATER_CENTER.x;
   const cz = HARBOR_WATER_CENTER.z;
 
+  // The water area is clipped to [westLimit, eastLimit]. By default, these are symmetric about the center.
   const westLimit = cx - halfX;
+  // If HARBOR_WATER_EAST_LIMIT is finite, use the smaller of that or the default east edge; otherwise, use the default.
   const eastLimit = Number.isFinite(HARBOR_WATER_EAST_LIMIT)
     ? Math.min(HARBOR_WATER_EAST_LIMIT, cx + halfX)
     : cx + halfX;


### PR DESCRIPTION
## Summary
- add a configurable eastward limit so harbor water stays on the seaward side of the pier
- update ocean clipping logic and debugging helpers to respect the asymmetric bounds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4fcc8e92483278cee24d3bf77d683