### PR TITLE
Support custom ocean clipping bounds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,9 +17,9 @@ import { updateCityLighting, createHillCity } from "./world/city.js";
 import {
   AGORA_CENTER_3D,
   HARBOR_CENTER_3D,
-  HARBOR_EXCLUDE_RADIUS,
   CITY_AREA_RADIUS,
   ACROPOLIS_PEAK_3D,
+  HARBOR_WATER_EAST_LIMIT,
 } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
@@ -252,7 +252,7 @@ async function mainApp() {
     position: HARBOR_CENTER_3D.clone(),
     bounds: {
       west: HARBOR_CENTER_3D.x - CITY_AREA_RADIUS * 4,
-      east: HARBOR_CENTER_3D.x + HARBOR_EXCLUDE_RADIUS * 0.4,
+      east: HARBOR_WATER_EAST_LIMIT,
       south: HARBOR_CENTER_3D.z - CITY_AREA_RADIUS * 2,
       north: HARBOR_CENTER_3D.z + CITY_AREA_RADIUS * 2,
     },


### PR DESCRIPTION
## Summary
- allow the ocean creation helper to accept explicit position, size, and rectangular bounds so the water mesh can be clipped asymmetrically
- clamp the ocean's east edge to the pier limit and update the dev debug helper to visualise the resolved bounds
- use the pier-aligned east bound when wiring createOcean in main.js

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e505380a188327807b339d5e1b407c