### PR TITLE
Adjust road visibility

### DIFF
--- a/src/world/roads_hillcity.js
+++ b/src/world/roads_hillcity.js
@@ -47,7 +47,7 @@ export function createMainHillRoad(scene, terrain) {
       const z = p.z + dir.z;
       let y = getH ? getH(x, z) : p.y;
       if (!Number.isFinite(y)) y = p.y;
-      y += 0.03; // small lift to avoid z-fighting with ground
+      y += 0.08; // increased lift to avoid z-fighting with ground
       pos.setXYZ(vertexIndex, x, y, z);
     }
   }
@@ -55,7 +55,7 @@ export function createMainHillRoad(scene, terrain) {
   geo.computeVertexNormals();
 
   const mat = new THREE.MeshStandardMaterial({
-    color: 0x575757,
+    color: 0x8a8a8a,
     roughness: 1,
     metalness: 0,
     side: THREE.DoubleSide,


### PR DESCRIPTION
## Summary
- raise the main hill road mesh further above the sampled terrain to reduce z-fighting
- brighten the road material to improve visibility against the ground

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e508bb61348327a9da4ff542acfe0a