### PR TITLE
feat: allow ocean creation to accept explicit world-space bounds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ import {
   HARBOR_CENTER_3D,
   CITY_AREA_RADIUS,
   ACROPOLIS_PEAK_3D,
-  HARBOR_WATER_EAST_LIMIT,
+  HARBOR_WATER_BOUNDS,
 } from "./world/locations.js";
 import { initializeAssetTranscoders } from "./world/landmarks.js";
 import { createCivicDistrict } from "./world/cityPlan.js";
@@ -248,15 +248,7 @@ async function mainApp() {
 
   // Width 6m; increase if needed (e.g., 8–10) to fully cover the area.
   addDepthOccluderRibbon(scene, terrain, P1, P2, 6 /* width */, 140 /* segments */);
-  const ocean = await createOcean(scene, {
-    position: HARBOR_CENTER_3D.clone(),
-    bounds: {
-      west: HARBOR_CENTER_3D.x - CITY_AREA_RADIUS * 4,
-      east: HARBOR_WATER_EAST_LIMIT,
-      south: HARBOR_CENTER_3D.z - CITY_AREA_RADIUS * 2,
-      north: HARBOR_CENTER_3D.z + CITY_AREA_RADIUS * 2,
-    },
-  });
+  const ocean = await createOcean(scene, { bounds: HARBOR_WATER_BOUNDS });
   const harbor = createHarbor(scene, { center: HARBOR_CENTER_3D });
   const envCollider = new EnvironmentCollider();
   scene.add(envCollider.mesh);

--- a/src/world/locations.js
+++ b/src/world/locations.js
@@ -46,6 +46,13 @@ export const PIER_EDGE_OFFSET = 4.5; // distance from harbor center to pier edge
 export const HARBOR_WATER_EAST_LIMIT = HARBOR_CENTER_3D.x - PIER_EDGE_OFFSET; // align with western (seaward) edge of pier
 export const HARBOR_WATER_BACK = 0; // max inland distance allowed (in Z half-extent)
 
+export const HARBOR_WATER_BOUNDS = {
+  west: -190,
+  east: -117,
+  north: -120,
+  south: 0,
+};
+
 // Convenience centers
 export const HARBOR_WATER_CENTER = new THREE.Vector3(
   HARBOR_CENTER_3D.x + HARBOR_WATER_OFFSET.x,


### PR DESCRIPTION
## Summary
- allow `createOcean` to accept explicit west/east/north/south bounds and size/clip the water plane accordingly
- retain the legacy center+size fallback, expose dev logging, and update debug helpers for the new bounds logic
- add reusable harbor water bounds and apply them at the call site so the ocean trims to the new rectangle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5082269c0832789aba524b1b61ebe