### PR TITLE
Lift features above terrain to avoid clipping

### DIFF
--- a/src/world/city.js
+++ b/src/world/city.js
@@ -14,6 +14,8 @@ import {
 import { createRoad } from "./roads.js";
 import { addFoundationPad } from "./foundations.js";
 
+const SURFACE_OFFSET = 0.05;
+
 const _matrix = new THREE.Matrix4();
 const _quaternion = new THREE.Quaternion();
 const _scale = new THREE.Vector3();
@@ -132,7 +134,10 @@ export function createCity(scene, terrain, options = {}) {
         continue;
       }
 
-      const groundHeight = Math.max(lot.height, SEA_LEVEL_Y + 0.05);
+      const groundHeight = Math.max(
+        lot.height + SURFACE_OFFSET,
+        SEA_LEVEL_Y + SURFACE_OFFSET
+      );
       placements.push({
         x: centerX,
         y: groundHeight,
@@ -157,7 +162,7 @@ export function createCity(scene, terrain, options = {}) {
     const alpha = i / 4;
     const x = origin.x - walkwaySpan * 0.5 + walkwaySpan * alpha;
     const z = origin.z + Math.sin(alpha * Math.PI * 1.2 - Math.PI * 0.3) * (gridSize.y * 0.45);
-    const y = sampleHeight(terrain, x, z, SEA_LEVEL_Y) + 0.02;
+    const y = sampleHeight(terrain, x, z, SEA_LEVEL_Y) + SURFACE_OFFSET;
     walkwayPoints.push(new THREE.Vector3(x, y, z));
   }
   if (walkwayPoints.length >= 2) {
@@ -342,7 +347,10 @@ export function createHillCity(scene, terrain, curve, opts = {}) {
 
     // foundation: clamp EVERY placement to terrain sample AFTER any nudges
     const ySample = getH ? getH(p.x, p.z) : p.y;
-    const baseY = Math.max(Number.isFinite(ySample) ? ySample : p.y, SEA_LEVEL_Y + MIN_ABOVE_SEA);
+    const liftedSample = Number.isFinite(ySample)
+      ? ySample + SURFACE_OFFSET
+      : p.y + SURFACE_OFFSET;
+    const baseY = Math.max(liftedSample, SEA_LEVEL_Y + MIN_ABOVE_SEA + SURFACE_OFFSET);
 
     const buildingScale = 0.9 + rng() * 0.3;
     const padRadius = Math.max(2.0, 1.8 * buildingScale);

--- a/src/world/cityPlan.js
+++ b/src/world/cityPlan.js
@@ -184,6 +184,8 @@ export function createCivicDistrict(scene, options = {}) {
     options.terrainSampler ??
     options.terrain?.userData?.getHeightAt;
 
+  const surfaceOffset = options.surfaceOffset ?? 0.05;
+
   const center = centerOption instanceof THREE.Vector3
     ? centerOption.clone()
     : new THREE.Vector3(
@@ -207,10 +209,10 @@ export function createCivicDistrict(scene, options = {}) {
       const worldZ = center.z + offsetZ;
       const sampled = terrainSampler(worldX, worldZ);
       if (Number.isFinite(sampled)) {
-        return sampled - baseHeight;
+        return sampled - baseHeight + surfaceOffset;
       }
     }
-    return fallback;
+    return fallback + surfaceOffset;
   };
 
   const promenade = createPavedStrip(promenadeWidth, plazaLength, 0xc3c2bb);
@@ -225,7 +227,7 @@ export function createCivicDistrict(scene, options = {}) {
 
   const greenRight = greenLeft.clone();
   greenRight.position.x = (promenadeWidth + greensWidth) / 2;
-  greenRight.position.y = sampleLocalHeight(greenRight.position.x, 0, greenRight.position.y ?? 0);
+  greenRight.position.y = sampleLocalHeight(greenRight.position.x, 0, 0);
   group.add(greenRight);
 
   const plazaNorth = createPavedStrip(promenadeWidth + greensWidth * 2, 18, 0xbdb8ac);
@@ -235,7 +237,7 @@ export function createCivicDistrict(scene, options = {}) {
 
   const plazaSouth = plazaNorth.clone();
   plazaSouth.position.z = -(plazaLength / 2 + 9);
-  plazaSouth.position.y = sampleLocalHeight(0, plazaSouth.position.z, plazaSouth.position.y ?? 0);
+  plazaSouth.position.y = sampleLocalHeight(0, plazaSouth.position.z, 0);
   group.add(plazaSouth);
 
   const fountain = createFountain();

--- a/src/world/roads_hillcity.js
+++ b/src/world/roads_hillcity.js
@@ -6,6 +6,8 @@ import {
   ACROPOLIS_PEAK_3D,
 } from "./locations.js";
 
+const SURFACE_OFFSET = 0.05;
+
 // scene + terrain required so we can drape to ground
 export function createMainHillRoad(scene, terrain) {
   // Gentle S-curve from harbor → agora → acropolis
@@ -47,7 +49,7 @@ export function createMainHillRoad(scene, terrain) {
       const z = p.z + dir.z;
       let y = getH ? getH(x, z) : p.y;
       if (!Number.isFinite(y)) y = p.y;
-      y += 0.03; // small lift to avoid z-fighting with ground
+      y += SURFACE_OFFSET; // lift to avoid z-fighting with ground
       pos.setXYZ(vertexIndex, x, y, z);
     }
   }


### PR DESCRIPTION
## Summary
- add a configurable surface offset when sampling civic district terrain so plazas, props, and buildings float above the ground
- raise procedural city placements and walkway points by a shared offset when clamping to terrain heights
- lift the hill road ribbon using the same surface offset to prevent it from being buried by the terrain mesh

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e50988aee08327a74bec188a0ba511