### PR TITLE
Enhance placeholder monument aesthetics and ground alignment

### DIFF
--- a/src/world/ground.js
+++ b/src/world/ground.js
@@ -1,0 +1,27 @@
+export const GROUND_EPSILON = 0.05;
+
+export function groundY(
+  terrain,
+  x,
+  z,
+  fallback = 0,
+  { clampToSea = false, seaLevel = 0, minAboveSea = 0 } = {}
+) {
+  const h = terrain?.userData?.getHeightAt?.(x, z);
+  let y = Number.isFinite(h) ? h : fallback;
+  if (clampToSea) y = Math.max(y, seaLevel + minAboveSea);
+  return y;
+}
+
+export function snapAboveGround(
+  mesh,
+  terrain,
+  x,
+  z,
+  epsilon = GROUND_EPSILON,
+  opts = {}
+) {
+  const base = groundY(terrain, x, z, mesh.position?.y ?? 0, opts);
+  mesh.position.y = base + epsilon;
+  return mesh.position.y;
+}


### PR DESCRIPTION
## Summary
- add a reusable ground helper module to sample terrain height and snap meshes just above it
- rebuild the placeholder monument with stepped base, column, cap, lighting, and AO-ready materials that sit above the ground and clamp to sea level

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e50e8652548327a7f495efb4284041