### PR TITLE
Fix landmark height sampling when using WorldRoot

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -545,6 +545,23 @@ async function mainApp() {
     root.name = WORLD_ROOT_NAME;
     scene.add(root);
     scene.userData.worldRoot = root;
+    const sceneUserData = scene.userData || {};
+    root.userData = root.userData || {};
+    if (sceneUserData.getHeightAt) {
+      root.userData.getHeightAt = sceneUserData.getHeightAt;
+    }
+    if (sceneUserData.terrainHeightSampler) {
+      root.userData.terrainHeightSampler = sceneUserData.terrainHeightSampler;
+    }
+    if (sceneUserData.heightSampler) {
+      root.userData.heightSampler = sceneUserData.heightSampler;
+    }
+    if (sceneUserData.terrainSampler) {
+      root.userData.terrainSampler = sceneUserData.terrainSampler;
+    }
+    if (sceneUserData.terrain) {
+      root.userData.terrain = sceneUserData.terrain;
+    }
     return root;
   };
 


### PR DESCRIPTION
## Summary
- copy terrain height sampler references from the scene onto the WorldRoot container so landmarks still find ground height when loaded through it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5d65ad0448327bb47003f10397027