### PR TITLE
Ensure GH Pages base entrypoint is generated

### DIFF
--- a/docs/athens-game-starter/index.html
+++ b/docs/athens-game-starter/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../favicon.ico" type="image/x-icon" />
+    <title>Athens Game Starter</title>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://esm.sh/three@0.160.0",
+          "three/": "https://esm.sh/three@0.160.0/",
+          "three/examples/": "https://esm.sh/three@0.160.0/examples/"
+        }
+      }
+    </script>
+    <script type="module" crossorigin src="../assets/index-ChAfUo35.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node scripts/ensure-three-bundled.mjs",
+    "build": "vite build && node scripts/ensure-three-bundled.mjs && node scripts/create-base-entrypoints.mjs",
     "preview": "vite preview --strictPort",
     "typecheck": "tsc -p . || true",
     "generate:favicon": "node scripts/generate-favicon.mjs",

--- a/scripts/create-base-entrypoints.mjs
+++ b/scripts/create-base-entrypoints.mjs
@@ -1,0 +1,53 @@
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+
+const OUTPUT_DIR = join(process.cwd(), 'docs');
+const BASE_DIR_NAME = 'athens-game-starter';
+const BASE_DIR = join(OUTPUT_DIR, BASE_DIR_NAME);
+
+async function pathExists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function toRelativeBase(content) {
+  return content.replace(/\/(athens-game-starter)\//g, '../');
+}
+
+async function writeRelativeCopy(sourcePath, destinationPath) {
+  if (!(await pathExists(sourcePath))) {
+    return;
+  }
+
+  const content = await readFile(sourcePath, 'utf8');
+  const relativeContent = toRelativeBase(content);
+  await mkdir(dirname(destinationPath), { recursive: true });
+  await writeFile(destinationPath, relativeContent, 'utf8');
+}
+
+async function main() {
+  const indexPath = join(OUTPUT_DIR, 'index.html');
+
+  if (!(await pathExists(indexPath))) {
+    console.error(`Missing build output: ${indexPath}`);
+    process.exit(1);
+  }
+
+  await mkdir(BASE_DIR, { recursive: true });
+
+  await writeRelativeCopy(indexPath, join(BASE_DIR, 'index.html'));
+
+  const root404Path = join(OUTPUT_DIR, '404.html');
+  if (await pathExists(root404Path)) {
+    await writeRelativeCopy(root404Path, join(BASE_DIR, '404.html'));
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a post-build script that mirrors the generated entrypoints into docs/athens-game-starter with relative asset paths
- update the build pipeline so npm run build produces the nested index required for subdirectory hosting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5dc26ec18832790d5717e932a0c54