### PR TITLE
fix: adjust soundscape manifest lookup

### DIFF
--- a/src/audio/soundscape.js
+++ b/src/audio/soundscape.js
@@ -119,7 +119,7 @@ export class Soundscape {
     return src;
   }
 
-  async initFromManifest(manifestUrl = "public/audio/manifest.json") {
+  async initFromManifest(manifestUrl = "audio/manifest.json") {
     const makeBaseUrl = () => {
       const rawBase = import.meta?.env?.BASE_URL ?? "/";
       const origin =


### PR DESCRIPTION
## Summary
- default soundscape manifest lookup to audio/manifest.json so candidate URLs cover SPA fallback scenario

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e5df6467648327824cddd7e50b76b5