### PR TITLE
Fix mirrored entrypoint asset paths

### DIFF
--- a/scripts/create-base-entrypoints.mjs
+++ b/scripts/create-base-entrypoints.mjs
@@ -18,7 +18,7 @@ async function pathExists(path) {
 }
 
 function toRelativeBase(content) {
-  return content.replace(/\/(athens-game-starter)\//g, '../');
+  return content.replace(/\/athens-game-starter\//g, './');
 }
 
 async function writeRelativeCopy(sourcePath, destinationPath) {


### PR DESCRIPTION
## Summary
- add a post-build script that mirrors the generated entrypoints into docs/athens-game-starter with relative asset paths
- update the build pipeline so npm run build produces the nested index required for subdirectory hosting
- correct the mirrored entrypoint rewrite to use ./ prefixes so GitHub Pages assets resolve from the subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5e402eaf8832789d1ca08b161730d