### PR TITLE
Align HUD lighting presets with sky cycle

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -53,25 +53,25 @@ const WORLD_ROOT_NAME = "WorldRoot";
 
 const LIGHTING_PRESETS = {
   dawn: {
-    phase: 0.25,
+    phase: 0.0,
     exposure: 0.9,
     label: "Dawn",
     hotkey: "1",
   },
   noon: {
-    phase: 0.5,
+    phase: 0.25,
     exposure: 1.5,
     label: "High Noon",
     hotkey: "2",
   },
   dusk: {
-    phase: 0.75,
+    phase: 0.5,
     exposure: 0.95,
     label: "Dusk",
     hotkey: "3",
   },
   night: {
-    phase: 0.0,
+    phase: 0.75,
     exposure: 0.6,
     label: "Night",
     hotkey: "4",


### PR DESCRIPTION
## Summary
- shift lighting preset phases so dawn, noon, dusk, and night align with the sky cycle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5e42b9dc48327baf1a8809cdf8997