### PR TITLE
fix: refresh Aristotle tomb collider after load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1215,14 +1215,24 @@ async function mainApp() {
       });
 
       root.position.set(x, y, z);
+      const shouldCollide = true;
+      root.userData = root.userData || {};
+      root.userData.noCollision = !shouldCollide;
+
       root.traverse((o) => {
         if (o?.isMesh) {
           o.castShadow = true;
           o.receiveShadow = true;
+          o.userData = o.userData || {};
+          o.userData.noCollision = !shouldCollide;
         }
       });
       root.name = "AristotleTomb";
       scene.add(root);
+
+      if (shouldCollide && typeof envCollider?.refresh === "function") {
+        envCollider.refresh();
+      }
 
       if (
         !url.includes("aristotle_tomb.glb") &&


### PR DESCRIPTION
## Summary
- add a shared GLB loader utility that retries fallback URLs, flags HTML responses, and normalizes height
- update the hero spawn and Aristotle's Tomb placement to use the safe loader, including scale and terrain snapping adjustments
- relocate the tomb asset under a landmarks directory and refresh docs/download scripts to match
- refresh the environment collider after loading Aristotle's Tomb so the landmark collides with the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5e80525988327aa7afa0c795309a3