### PR TITLE
Fix mirrored entrypoint asset paths (follow-up)

### DIFF
--- a/scripts/create-base-entrypoints.mjs
+++ b/scripts/create-base-entrypoints.mjs
@@ -25,7 +25,7 @@ async function pathExists(path) {
 }
 
 function toRelativeBase(content) {
-  return content.replace(/\/athens-game-starter\//g, './');
+  return content.replace(/\/athens-game-starter\//g, '../');
 }
 
 async function writeRelativeCopy(sourcePath, destinationPath) {


### PR DESCRIPTION
## Summary
- restore the `../` prefix when rewriting `/athens-game-starter/` links so mirrored entrypoints continue loading assets from the parent directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5ed9132f483278c7b310ec1d44b09