### PR TITLE
Refactor base URL helper for shared use

### DIFF
--- a/src/audio/soundscape.js
+++ b/src/audio/soundscape.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { resolveAbsoluteBaseUrl, resolveBaseUrl } from "../utils/baseUrl.js";
 
 /**
  * Living City Soundscape
@@ -120,20 +121,9 @@ export class Soundscape {
   }
 
   async initFromManifest(manifestUrl = "audio/manifest.json") {
-    const makeBaseUrl = () => {
-      const rawBase = import.meta?.env?.BASE_URL ?? "/";
-      const origin =
-        typeof window !== "undefined" && window.location?.origin
-          ? window.location.origin
-          : "http://localhost";
-      try {
-        return new URL(rawBase, origin);
-      } catch {
-        return new URL("/", origin);
-      }
-    };
-
-    const baseUrl = makeBaseUrl();
+    const absoluteBaseUrl = resolveAbsoluteBaseUrl();
+    const basePath = resolveBaseUrl();
+    const baseUrl = absoluteBaseUrl;
     const resolveAssetPath = (path) => {
       if (!path) return path;
       try {
@@ -163,7 +153,7 @@ export class Soundscape {
 
     const candidates = [
       resolveAssetPath(manifestUrl),
-      resolveAssetPath(`${import.meta?.env?.BASE_URL ?? "/"}audio/manifest.json`)
+      resolveAssetPath(`${basePath}audio/manifest.json`)
     ];
 
     let mf = null;

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,7 @@ import { attachHeightSampler } from "./world/terrainHeight.js";
 import { addDepthOccluderRibbon } from "./world/occluders.js";
 import { snapAboveGround } from "./world/ground.js";
 import { loadGLBWithFallbacks } from "./utils/glbSafeLoader.js";
+import { resolveBaseUrl } from "./utils/baseUrl.js";
 
 const WORLD_ROOT_NAME = "WorldRoot";
 
@@ -114,70 +115,6 @@ async function resolveFirstAvailableAsset(urls) {
 window.addEventListener("unhandledrejection", (ev) => {
   console.error("Unhandled promise rejection:", ev.reason);
 });
-
-function getImportMeta() {
-  try {
-    return import.meta;
-  } catch (error) {
-    console.debug("import.meta is not available in this environment", error);
-    return undefined;
-  }
-}
-
-function ensureTrailingSlash(value) {
-  if (typeof value !== "string" || value.length === 0) return value;
-  return value.endsWith("/") ? value : `${value}/`;
-}
-
-function deriveBundledBaseUrl() {
-  const importMeta = getImportMeta();
-  if (!importMeta || typeof importMeta.url !== "string") {
-    return null;
-  }
-
-  try {
-    const bundleUrl = new URL(importMeta.url);
-    const { pathname } = bundleUrl;
-    const assetsIndex = pathname.lastIndexOf("/assets/");
-    if (assetsIndex >= 0) {
-      const basePath = pathname.slice(0, assetsIndex + 1);
-      return ensureTrailingSlash(basePath);
-    }
-  } catch (error) {
-    console.debug("Failed to derive bundled base URL from import.meta.url", error);
-  }
-
-  return null;
-}
-
-function resolveBaseUrl() {
-  const importMeta = getImportMeta();
-  const envBase = importMeta && importMeta.env ? importMeta.env.BASE_URL : undefined;
-  if (typeof envBase === "string" && envBase.length > 0 && envBase !== "/") {
-    return ensureTrailingSlash(envBase);
-  }
-
-  const bundledBase = deriveBundledBaseUrl();
-  if (bundledBase) {
-    return bundledBase;
-  }
-
-  if (typeof envBase === "string" && envBase.length > 0) {
-    return ensureTrailingSlash(envBase);
-  }
-
-  if (typeof window !== "undefined" && typeof window.location?.pathname === "string") {
-    const { pathname } = window.location;
-    if (pathname && pathname !== "") {
-      const lastSlash = pathname.lastIndexOf("/");
-      if (lastSlash >= 0) {
-        return ensureTrailingSlash(pathname.slice(0, lastSlash + 1));
-      }
-    }
-  }
-
-  return "/";
-}
 
 const BASE_URL = resolveBaseUrl();
 

--- a/src/utils/baseUrl.js
+++ b/src/utils/baseUrl.js
@@ -1,0 +1,77 @@
+function getImportMeta() {
+  try {
+    return import.meta;
+  } catch (error) {
+    console.debug("import.meta is not available in this environment", error);
+    return undefined;
+  }
+}
+
+function ensureTrailingSlash(value) {
+  if (typeof value !== "string" || value.length === 0) return value;
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function deriveBundledBaseUrl() {
+  const importMeta = getImportMeta();
+  if (!importMeta || typeof importMeta.url !== "string") {
+    return null;
+  }
+
+  try {
+    const bundleUrl = new URL(importMeta.url);
+    const { pathname } = bundleUrl;
+    const assetsIndex = pathname.lastIndexOf("/assets/");
+    if (assetsIndex >= 0) {
+      const basePath = pathname.slice(0, assetsIndex + 1);
+      return ensureTrailingSlash(basePath);
+    }
+  } catch (error) {
+    console.debug("Failed to derive bundled base URL from import.meta.url", error);
+  }
+
+  return null;
+}
+
+export function resolveBaseUrl() {
+  const importMeta = getImportMeta();
+  const envBase = importMeta && importMeta.env ? importMeta.env.BASE_URL : undefined;
+  if (typeof envBase === "string" && envBase.length > 0 && envBase !== "/") {
+    return ensureTrailingSlash(envBase);
+  }
+
+  const bundledBase = deriveBundledBaseUrl();
+  if (bundledBase) {
+    return bundledBase;
+  }
+
+  if (typeof envBase === "string" && envBase.length > 0) {
+    return ensureTrailingSlash(envBase);
+  }
+
+  if (typeof window !== "undefined" && typeof window.location?.pathname === "string") {
+    const { pathname } = window.location;
+    if (pathname && pathname !== "") {
+      const lastSlash = pathname.lastIndexOf("/");
+      if (lastSlash >= 0) {
+        return ensureTrailingSlash(pathname.slice(0, lastSlash + 1));
+      }
+    }
+  }
+
+  return "/";
+}
+
+export function resolveAbsoluteBaseUrl() {
+  const baseUrl = resolveBaseUrl();
+  if (typeof window === "undefined" || !window.location?.origin) {
+    return new URL(baseUrl, "http://localhost");
+  }
+
+  try {
+    return new URL(baseUrl, window.location.origin);
+  } catch {
+    return new URL("/", window.location.origin);
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract the base URL resolver from main.js into src/utils/baseUrl.js
- reuse the shared helper in main initialization and the audio soundscape manifest loader
- ensure the soundscape manifest probe resolves against the shared base prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5eef92bc48327b403010590fea079