### PR TITLE
Fix preview asset paths for nested base directory

### DIFF
--- a/docs/athens-game-starter/index.html
+++ b/docs/athens-game-starter/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="./favicon.ico" type="image/x-icon" />
+    <link rel="icon" href="../favicon.ico" type="image/x-icon" />
     <title>Athens Game Starter</title>
 
     <script type="importmap">
@@ -15,7 +15,7 @@
         }
       }
     </script>
-    <script type="module" crossorigin src="./assets/index-_TgdUSWV.js"></script>
+    <script type="module" crossorigin src="../assets/index-_TgdUSWV.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/scripts/create-base-entrypoints.mjs
+++ b/scripts/create-base-entrypoints.mjs
@@ -18,7 +18,9 @@ async function pathExists(path) {
 }
 
 function toRelativeBase(content) {
-  return content.replace(/\/(athens-game-starter)\//g, '../');
+  return content
+    .replace(/\/(athens-game-starter)\//g, '../')
+    .replace(/(src|href)=("|')\.\//g, (match) => match.replace('./', '../'));
 }
 
 async function writeRelativeCopy(sourcePath, destinationPath) {


### PR DESCRIPTION
## Summary
- update the entrypoint copy script to rewrite leading "./" href/src references when generating the nested base directory
- regenerate the nested GitHub Pages entrypoint so it now points at the shared favicon and bundle via "../" paths

## Testing
- npm run build
- npx vite preview --strictPort --port 4173

------
https://chatgpt.com/codex/tasks/task_b_68e621a97dc48327bee4dbc6a2de3f38