### PR TITLE
Fix docs subapp asset path

### DIFF
--- a/docs/athens-game-starter/index.html
+++ b/docs/athens-game-starter/index.html
@@ -15,7 +15,7 @@
         }
       }
     </script>
-    <script type="module" crossorigin src="./assets/index-_TgdUSWV.js"></script>
+    <script type="module" crossorigin src="../assets/index-_TgdUSWV.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## Summary
- point the docs subapp HTML back to the shared assets directory so the bundle loads correctly

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_b_68e62a3e47048327925dddde1055a63d