### PR TITLE
Adjust player spawn offset above ground

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -623,7 +623,9 @@ async function mainApp() {
 
   const spawnPosition = new THREE.Vector3(0, 0, 10);
   player.object.position.copy(spawnPosition);
-  snapAboveGround(player.object, terrain, spawnPosition.x, spawnPosition.z, 0.1, {
+  const spawnClearance = 0.1;
+  const spawnOffset = player.height * 0.5 + spawnClearance;
+  snapAboveGround(player.object, terrain, spawnPosition.x, spawnPosition.z, spawnOffset, {
     clampToSea: true,
     seaLevel: SEA_LEVEL_Y,
     minAboveSea: 0.25,


### PR DESCRIPTION
## Summary
- add an explicit clearance and capsule half-height offset when snapping the player spawn to the ground

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e640261e2c83279181b1ef7e25f5c6