### PR TITLE
Fix civic district collision so player stays above ground

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -621,6 +621,10 @@ async function mainApp() {
     terrain,
   });
 
+  // Rebuild the collider again now that the civic district geometry exists so the
+  // player can stand on the new plazas instead of falling through them.
+  envCollider.refresh();
+
   const input = new InputMap(renderer.domElement);
   const player = new PlayerController(input, envCollider, { camera });
   worldRoot.add(player.object);

--- a/src/world/cityPlan.js
+++ b/src/world/cityPlan.js
@@ -11,7 +11,6 @@ function createPavedStrip(width, depth, color) {
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.receiveShadow = true;
-  mesh.userData.noCollision = true;
   return mesh;
 }
 
@@ -25,7 +24,6 @@ function createGreenStrip(width, depth, color) {
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.receiveShadow = true;
-  mesh.userData.noCollision = true;
   return mesh;
 }
 


### PR DESCRIPTION
## Summary
- allow civic district plaza surface meshes to participate in collision generation
- refresh the environment collider after placing the civic district so the new geometry is included

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e64d8ab6508327bd84ba7639918d3e