### PR TITLE
Add roads visibility toggle

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -591,8 +591,27 @@ async function mainApp() {
 
   const worldRoot = refreshWorldRoot();
 
+  const roadsVisible = (() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    try {
+      const params = new URLSearchParams(window.location.search);
+      if (!params.has("roads")) {
+        return true;
+      }
+      return parseToggleValue(params.get("roads"), true);
+    } catch (error) {
+      console.warn("Failed to parse roads visibility from query string:", error);
+      return true;
+    }
+  })();
+
   // Roads first (needs terrain sampler)
   const { group: roadGroup, curve: mainRoad } = createMainHillRoad(worldRoot, terrain);
+  if (roadGroup) {
+    roadGroup.visible = roadsVisible;
+  }
   if (import.meta.env?.DEV) {
     mountHillCityDebug(scene, mainRoad);
   }

--- a/src/world/city.js
+++ b/src/world/city.js
@@ -198,6 +198,7 @@ export function createCity(scene, terrain, options = {}) {
   const spacingZ = options.spacingZ ?? 10;
   const jitter = options.jitter ?? 2.2;
   const maxSlope = options.maxSlope ?? 1.4;
+  const roadsVisible = options.roadsVisible == null ? true : Boolean(options.roadsVisible);
 
   const countX = Math.max(3, Math.floor(gridSize.x / spacingX));
   const countZ = Math.max(3, Math.floor(gridSize.y / spacingZ));
@@ -319,6 +320,7 @@ export function createCity(scene, terrain, options = {}) {
     roadsMesh.userData.noCollision = true; // visual only
     roadsMesh.castShadow = false;
     roadsMesh.receiveShadow = true;
+    roadsMesh.visible = roadsVisible;
     city.add(roadsMesh);
   }
 
@@ -332,13 +334,16 @@ export function createCity(scene, terrain, options = {}) {
     walkwayPoints.push(new THREE.Vector3(x, y, z));
   }
   if (walkwayPoints.length >= 2) {
-    createRoad(city, walkwayPoints, {
+    const walkway = createRoad(city, walkwayPoints, {
       width: 3.2,
       segments: 64,
       name: "CityWalkway",
       noCollision: true,
       color: 0x4b3f35,
     });
+    if (walkway) {
+      walkway.visible = roadsVisible;
+    }
   }
 
   const instanceCount = placements.length;


### PR DESCRIPTION
## Summary
- parse an optional `?roads=` query parameter to toggle the visibility of the main hill road
- respect a `roadsVisible` option inside `createCity` so merged road and walkway meshes can be hidden together

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e651abe8688327b77046c340e08444