### PR TITLE
Guard harbor sea level during city flatten

### DIFF
--- a/src/world/terrain.js
+++ b/src/world/terrain.js
@@ -134,7 +134,15 @@ export function createTerrain(scene) {
         // Blend original 'height' toward city target elevation.
         // Inside inner radius, t≈0 → almost perfectly flat at CITY_TARGET_Y.
         // Between inner and outer, gradually blend back to natural terrain.
-        height = THREE.MathUtils.lerp(CITY_TARGET_Y, height, t);
+        const heightBeforeCity = height;
+        const cityHeight = THREE.MathUtils.lerp(CITY_TARGET_Y, heightBeforeCity, t);
+        if (distance < HARBOR_OUTER_RADIUS) {
+          // Preserve the harbor's sea level flattening by never raising terrain
+          // above the value established by the harbor pass.
+          height = Math.min(heightBeforeCity, cityHeight);
+        } else {
+          height = cityHeight;
+        }
       }
     }
     positionAttribute.setZ(i, height);


### PR DESCRIPTION
## Summary
- flatten the terrain near the Agora by blending heights toward the plaza elevation within the city radius
- smooth the transition between the city plateau and surrounding hills using lerped falloff
- reduce terrain sway within the city area so structures rest on stable ground
- preserve the harbor's sea-level clamp when city plateau blending overlaps its radius

## Testing
- npm run test -- --watch=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68e6579ad5408327ba37212f63884d48