### PR TITLE
Move terrain sway to GPU shader

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1530,8 +1530,7 @@ async function mainApp() {
     updateStars(stars, phase);
     updateMoon(moon, sunDir);
 
-    // Dynamic terrain subtly sways, hinting at wind. Remove this call if you
-    // prefer a static landscape without vertex animation.
+    // Advance the GPU-driven terrain sway (no CPU vertex updates required).
     updateTerrain(terrain, elapsed);
     updateOcean(ocean, deltaTime, sunDir, lights.nightFactor);
 


### PR DESCRIPTION
## Summary
- add GPU-driven sway to the terrain material while preserving vertex colors
- retain CPU-side height sampling via stored base heights and expose uniforms for updates
- update the main loop comment to reflect the shader-driven animation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e65ab00f508327889c5261a1abfead